### PR TITLE
Syslog / Loggly / Refactor

### DIFF
--- a/lib/cloudwatchlogs/init.go
+++ b/lib/cloudwatchlogs/init.go
@@ -3,5 +3,5 @@ package cloudwatchlogs
 import "github.com/segmentio/ecs-logs/lib"
 
 func init() {
-	ecslogs.RegisterDestination("cloudwatchlogs", ecslogs.DestinationFunc(NewMessageBatchWriter))
+	ecslogs.RegisterDestination("cloudwatchlogs", ecslogs.DestinationFunc(NewWriter))
 }

--- a/lib/cloudwatchlogs/init.go
+++ b/lib/cloudwatchlogs/init.go
@@ -1,4 +1,4 @@
-package cwl
+package cloudwatchlogs
 
 import "github.com/segmentio/ecs-logs/lib"
 

--- a/lib/cloudwatchlogs/region.go
+++ b/lib/cloudwatchlogs/region.go
@@ -1,4 +1,4 @@
-package cwl
+package cloudwatchlogs
 
 import (
 	"encoding/json"

--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -2,6 +2,7 @@ package cloudwatchlogs
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -109,8 +110,9 @@ func makeLogEvents(batch []ecslogs.Message) (events []*cloudwatchlogs.InputLogEv
 
 	for _, msg := range batch {
 		if len(msg.Content) != 0 {
+			msg.Time = time.Time{}
 			events = append(events, &cloudwatchlogs.InputLogEvent{
-				Message:   aws.String(msg.Content),
+				Message:   aws.String(msg.String()),
 				Timestamp: aws.Int64(aws.TimeUnixMilli(msg.Time)),
 			})
 		}

--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -1,4 +1,4 @@
-package cwl
+package cloudwatchlogs
 
 import (
 	"fmt"

--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -110,6 +110,10 @@ func makeLogEvents(batch []ecslogs.Message) (events []*cloudwatchlogs.InputLogEv
 
 	for _, msg := range batch {
 		if len(msg.Content) != 0 {
+			// Set the message properties to their zero-value so they are omitted when
+			// serialized to JSON by the String method.
+			msg.Group = ""
+			msg.Stream = ""
 			msg.Time = time.Time{}
 			events = append(events, &cloudwatchlogs.InputLogEvent{
 				Message:   aws.String(msg.String()),

--- a/lib/destination.go
+++ b/lib/destination.go
@@ -35,6 +35,19 @@ func GetDestination(name string) (destination Destination) {
 	return
 }
 
+func GetDestinations(names ...string) (destinations []Destination) {
+	if len(names) != 0 {
+		destinations = make([]Destination, 0, len(names))
+
+		for _, name := range names {
+			if destination := GetDestination(name); destination != nil {
+				destinations = append(destinations, destination)
+			}
+		}
+	}
+	return
+}
+
 func DestinationsAvailable() (destinations []string) {
 	dstmtx.RLock()
 	destinations = make([]string, 0, len(dstmap))

--- a/lib/destination.go
+++ b/lib/destination.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Destination interface {
-	Open(group string, stream string) (MessageBatchWriteCloser, error)
+	Open(group string, stream string) (Writer, error)
 }
 
-type DestinationFunc func(group string, stream string) (MessageBatchWriteCloser, error)
+type DestinationFunc func(group string, stream string) (Writer, error)
 
-func (f DestinationFunc) Open(group string, stream string) (MessageBatchWriteCloser, error) {
+func (f DestinationFunc) Open(group string, stream string) (Writer, error) {
 	return f(group, stream)
 }
 
@@ -51,7 +51,7 @@ func DestinationsAvailable() (destinations []string) {
 var (
 	dstmtx sync.RWMutex
 	dstmap = map[string]Destination{
-		"stdout": DestinationFunc(func(_ string, _ string) (MessageBatchWriteCloser, error) {
+		"stdout": DestinationFunc(func(_ string, _ string) (Writer, error) {
 			return NewMessageEncoder(os.Stdout), nil
 		}),
 	}

--- a/lib/destination.go
+++ b/lib/destination.go
@@ -36,15 +36,14 @@ func GetDestination(name string) (destination Destination) {
 }
 
 func GetDestinations(names ...string) (destinations []Destination) {
-	if len(names) != 0 {
-		destinations = make([]Destination, 0, len(names))
+	destinations = make([]Destination, 0, len(names))
 
-		for _, name := range names {
-			if destination := GetDestination(name); destination != nil {
-				destinations = append(destinations, destination)
-			}
+	for _, name := range names {
+		if destination := GetDestination(name); destination != nil {
+			destinations = append(destinations, destination)
 		}
 	}
+
 	return
 }
 

--- a/lib/journald/init.go
+++ b/lib/journald/init.go
@@ -5,5 +5,5 @@ package journald
 import "github.com/segmentio/ecs-logs/lib"
 
 func init() {
-	ecslogs.RegisterSource("journald", ecslogs.SourceFunc(NewMessageReader))
+	ecslogs.RegisterSource("journald", ecslogs.SourceFunc(NewReader))
 }

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -80,7 +80,7 @@ func (r reader) getMessage() (msg ecslogs.Message, ok bool, err error) {
 }
 
 func (r reader) getInt(k string) (v int) {
-	if s, e := r.getString(j, k); err == nil {
+	if s, e := r.getString(j, k); e == nil {
 		v = strconv.Atoi(s)
 	}
 	return

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -35,12 +35,12 @@ func (r reader) ReadMessage() (msg ecslogs.Message, err error) {
 		var cur int
 		var ok bool
 
-		if cur, err = r.j.Next(); err != nil {
+		if cur, err = r.Next(); err != nil {
 			return
 		}
 
 		if cur == 0 {
-			r.j.Wait(sdjournal.IndefiniteWait)
+			r.Wait(sdjournal.IndefiniteWait)
 			continue
 		}
 

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -80,9 +80,7 @@ func (r reader) getMessage() (msg ecslogs.Message, ok bool, err error) {
 }
 
 func (r reader) getInt(k string) (v int) {
-	if s, e := r.getString(k); e == nil {
-		v = strconv.Atoi(s)
-	}
+	v, _ = strconv.Atoi(r.getString(k))
 	return
 }
 
@@ -94,9 +92,7 @@ func (r reader) getTime() (t time.Time) {
 }
 
 func (r reader) getPriority() (p ecslogs.Level) {
-	if s, e := r.getString("PRIORITY"); e != nil {
-		p = ecslogs.INFO
-	} else if v, e := strconv.Atoi(s); e != nil {
+	if v, e := strconv.Atoi(r.getString("PRIORITY")); e != nil {
 		p = ecslogs.INFO
 	} else {
 		p = ecslogs.Level(v)

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -80,7 +80,7 @@ func (r reader) getMessage() (msg ecslogs.Message, ok bool, err error) {
 }
 
 func (r reader) getInt(k string) (v int) {
-	if s, e := r.getString(j, k); e == nil {
+	if s, e := r.getString(k); e == nil {
 		v = strconv.Atoi(s)
 	}
 	return
@@ -94,7 +94,7 @@ func (r reader) getTime() (t time.Time) {
 }
 
 func (r reader) getPriority() (p ecslogs.Level) {
-	if s, e := r.getString(j, "PRIORITY"); e != nil {
+	if s, e := r.getString("PRIORITY"); e != nil {
 		p = ecslogs.INFO
 	} else if v, e := strconv.Atoi(s); e != nil {
 		p = ecslogs.INFO

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -3,6 +3,7 @@
 package journald
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/coreos/go-systemd/sdjournal"
@@ -72,6 +73,23 @@ func (r journalReader) getMessage() (msg ecslogs.Message, ok bool, err error) {
 		return
 	}
 
+	if s, e := r.j.GetDataValue("PRIORITY"); e != nil {
+		msg.Level = ecslogs.INFO
+	} else if v, e := strconv.Atoi(s); e != nil {
+		msg.Level = ecslogs.INFO
+	} else {
+		msg.Level = ecslogs.Level(v)
+	}
+
+	msg.PID, _ = r.j.GetDataValue("_PID")
+	msg.UID, _ = r.j.GetDataValue("_UID")
+	msg.GID, _ = r.j.GetDataValue("_GID")
+	msg.Errno, _ = r.j.GetDataValue("ERRNO")
+	msg.Line, _ = r.j.GetDataValue("CODE_LINE")
+	msg.Func, _ = r.j.GetDataValue("CODE_FUNC")
+	msg.File, _ = r.j.GetDataValue("CODE_FILE")
+	msg.ID, _ = r.j.GetDataValue("MESSAGE_ID")
+	msg.Host, _ = r.j.GetDataValue("_HOSTNAME")
 	msg.Time = time.Unix(int64(usec/1000000), int64((usec%1000000)*1000))
 	ok = true
 	return

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -86,7 +86,7 @@ func (r reader) getInt(k string) (v int) {
 
 func (r reader) getTime() (t time.Time) {
 	if u, e := r.GetRealtimeUsec(); e == nil {
-		t = time.Unix(int64(usec/1000000), int64((usec%1000000)*1000))
+		t = time.Unix(int64(u/1000000), int64((u%1000000)*1000))
 	}
 	return
 }

--- a/lib/level.go
+++ b/lib/level.go
@@ -1,6 +1,7 @@
 package ecslogs
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -78,24 +79,23 @@ func (lvl Level) String() string {
 	}
 }
 
-func (lvl Level) GoString() string {
-	return lvl.String()
-}
-
-func (lvl Level) MarshalText() (b []byte, err error) {
-	b = []byte(lvl.String())
-	return
-}
-
 func (lvl Level) MarshalJSON() (b []byte, err error) {
-	return lvl.MarshalText()
-}
-
-func (lvl *Level) UnmarshalText(b []byte) (err error) {
-	*lvl, err = ParseLevel(string(b))
-	return
+	return json.Marshal(lvl.String())
 }
 
 func (lvl *Level) UnmarshalJSON(b []byte) (err error) {
-	return lvl.UnmarshalText(b)
+	var v int
+	var s string
+
+	if err = json.Unmarshal(b, &v); err == nil {
+		*lvl = Level(v)
+		return
+	}
+
+	if err = json.Unmarshal(b, &s); err == nil {
+		*lvl, err = ParseLevel(s)
+		return
+	}
+
+	return
 }

--- a/lib/level.go
+++ b/lib/level.go
@@ -2,6 +2,7 @@ package ecslogs
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -45,7 +46,11 @@ func ParseLevel(s string) (lvl Level, err error) {
 	case "DEBUG":
 		lvl = DEBUG
 	default:
-		err = ParseLevelError{s}
+		if v, e := strconv.ParseInt(s, 10, 64); e != nil {
+			err = ParseLevelError{s}
+		} else {
+			lvl = Level(v)
+		}
 	}
 	return
 }
@@ -69,6 +74,28 @@ func (lvl Level) String() string {
 	case DEBUG:
 		return "DEBUG"
 	default:
-		return fmt.Sprintf("<%d>", lvl)
+		return strconv.Itoa(int(lvl))
 	}
+}
+
+func (lvl Level) GoString() string {
+	return lvl.String()
+}
+
+func (lvl Level) MarshalText() (b []byte, err error) {
+	b = []byte(lvl.String())
+	return
+}
+
+func (lvl Level) MarshalJSON() (b []byte, err error) {
+	return lvl.MarshalText()
+}
+
+func (lvl *Level) UnmarshalText(b []byte) (err error) {
+	*lvl, err = ParseLevel(string(b))
+	return
+}
+
+func (lvl *Level) UnmarshalJSON(b []byte) (err error) {
+	return lvl.UnmarshalText(b)
 }

--- a/lib/level.go
+++ b/lib/level.go
@@ -1,0 +1,74 @@
+package ecslogs
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Level int
+
+const (
+	EMERGENCY Level = iota
+	ALERT
+	CRITICAL
+	ERROR
+	WARNING
+	NOTICE
+	INFO
+	DEBUG
+)
+
+type ParseLevelError struct {
+	Level string
+}
+
+func (e ParseLevelError) Error() string {
+	return fmt.Sprintf("invalid message level %#v", e.Level)
+}
+
+func ParseLevel(s string) (lvl Level, err error) {
+	switch strings.ToUpper(s) {
+	case "EMERGENCY":
+		lvl = EMERGENCY
+	case "ALERT":
+		lvl = ALERT
+	case "CRITICAL":
+		lvl = CRITICAL
+	case "ERROR":
+		lvl = ERROR
+	case "WARNING":
+		lvl = WARNING
+	case "NOTICE":
+		lvl = NOTICE
+	case "INFO":
+		lvl = INFO
+	case "DEBUG":
+		lvl = DEBUG
+	default:
+		err = ParseLevelError{s}
+	}
+	return
+}
+
+func (lvl Level) String() string {
+	switch lvl {
+	case EMERGENCY:
+		return "EMERGENCY"
+	case ALERT:
+		return "ALERT"
+	case CRITICAL:
+		return "CRITICAL"
+	case ERROR:
+		return "ERROR"
+	case WARNING:
+		return "WARNING"
+	case NOTICE:
+		return "NOTICE"
+	case INFO:
+		return "INFO"
+	case DEBUG:
+		return "DEBUG"
+	default:
+		return fmt.Sprintf("<%d>", lvl)
+	}
+}

--- a/lib/level_test.go
+++ b/lib/level_test.go
@@ -52,9 +52,9 @@ func TestParseLevelSuccess(t *testing.T) {
 
 func TestParseLevelFailure(t *testing.T) {
 	if _, err := ParseLevel(""); err == nil {
-		t.Errorf("no error returned when parsing an invalid log level")
+		t.Error("no error returned when parsing an invalid log level")
 	} else if s := err.Error(); s != "invalid message level \"\"" {
-		t.Errorf("invalid error message returned when parsing an invalid log level:", s)
+		t.Error("invalid error message returned when parsing an invalid log level:", s)
 	}
 }
 

--- a/lib/level_test.go
+++ b/lib/level_test.go
@@ -1,0 +1,67 @@
+package ecslogs
+
+import "testing"
+
+var levelTests = []struct {
+	lvl Level
+	str string
+}{
+	{
+		lvl: EMERGENCY,
+		str: "EMERGENCY",
+	},
+	{
+		lvl: ALERT,
+		str: "ALERT",
+	},
+	{
+		lvl: CRITICAL,
+		str: "CRITICAL",
+	},
+	{
+		lvl: ERROR,
+		str: "ERROR",
+	},
+	{
+		lvl: WARNING,
+		str: "WARNING",
+	},
+	{
+		lvl: NOTICE,
+		str: "NOTICE",
+	},
+	{
+		lvl: INFO,
+		str: "INFO",
+	},
+	{
+		lvl: DEBUG,
+		str: "DEBUG",
+	},
+}
+
+func TestParseLevelSuccess(t *testing.T) {
+	for _, test := range levelTests {
+		if lvl, err := ParseLevel(test.str); err != nil {
+			t.Errorf("%s: error: %s", test.str, err)
+		} else if lvl != test.lvl {
+			t.Errorf("%s: invalid level: %s", test.str, lvl)
+		}
+	}
+}
+
+func TestParseLevelFailure(t *testing.T) {
+	if _, err := ParseLevel(""); err == nil {
+		t.Errorf("no error returned when parsing an invalid log level")
+	} else if s := err.Error(); s != "invalid message level \"\"" {
+		t.Errorf("invalid error message returned when parsing an invalid log level:", s)
+	}
+}
+
+func TestLevelString(t *testing.T) {
+	for _, test := range levelTests {
+		if s := test.lvl.String(); s != test.str {
+			t.Errorf("%s: invalid string: %s", test.lvl, s)
+		}
+	}
+}

--- a/lib/loggly/init.go
+++ b/lib/loggly/init.go
@@ -1,0 +1,7 @@
+package loggly
+
+import "github.com/segmentio/ecs-logs/lib"
+
+func init() {
+	ecslogs.RegisterDestination("loggly", ecslogs.DestinationFunc(NewWriter))
+}

--- a/lib/loggly/writer.go
+++ b/lib/loggly/writer.go
@@ -18,6 +18,8 @@ func NewWriter(group string, stream string) (w ecslogs.Writer, err error) {
 	var token string
 	var pen string
 	var tags string
+	var template string
+	var timeFormat string
 
 	if endpoint, err = getEndpoint(); err != nil {
 		return
@@ -27,11 +29,20 @@ func NewWriter(group string, stream string) (w ecslogs.Writer, err error) {
 		return
 	}
 
+	if template = os.Getenv("LOGGLY_TEMPLATE"); len(template) == 0 {
+		template = "<{{.PRIVAL}}>1 {{.TIMESTAMP}} {{.HOSTNAME}} {{.GROUP}} {{.PROCID}} {{.MSGID}} [{{.TAG}}] {{.MSG}}"
+	}
+
+	if timeFormat = os.Getenv("LOGGLY_TIME_FORMAT"); len(timeFormat) == 0 {
+		timeFormat = "2006-01-02T15:04:05.999Z07:00"
+	}
+
 	return syslog.DialWriter(syslog.WriterConfig{
 		Network:    protocol,
 		Address:    address,
-		Template:   fmt.Sprintf("<{{.PRIVAL}}>1 {{.TIMESTAMP}} {{.HOSTNAME}} {{.GROUP}} {{.PROCID}} {{.MSGID}} [%s@%s %s] {{.MSG}}", token, pen, tags),
-		TimeFormat: "2006-01-02T15:04:05.999Z07:00",
+		Template:   template,
+		TimeFormat: timeFormat,
+		Tag:        fmt.Sprintf("%s@%s %s", token, pen, tags),
 		TLS: &tls.Config{
 			InsecureSkipVerify: true,
 		},

--- a/lib/loggly/writer.go
+++ b/lib/loggly/writer.go
@@ -46,7 +46,7 @@ func getEndpoint() (endpoint string, err error) {
 	}
 
 	if token = os.Getenv("LOGGLY_TOKEN"); len(token) != 0 {
-		endpoint = "tls://logs-01.loggly.com:6514/?token=" + url.QueryEscape(token)
+		endpoint = "tls://" + token + "@logs-01.loggly.com:6514"
 		return
 	}
 
@@ -76,11 +76,11 @@ func parseEndpoint(endpoint string, group string, stream string) (protocol strin
 		return
 	}
 
-	if token, err = extractToken(u, q); err != nil {
+	if token, err = extractToken(u); err != nil {
 		return
 	}
 
-	pen = extractPEN(u, q)
+	pen = extractPEN(u)
 	tags = extractTags(u, q, group, stream)
 	return
 }
@@ -106,17 +106,27 @@ func extractAddress(u *url.URL) (address string, err error) {
 	return
 }
 
-func extractToken(u *url.URL, q url.Values) (token string, err error) {
-	if token = q.Get("token"); len(token) == 0 {
+func extractToken(u *url.URL) (token string, err error) {
+	if u.User != nil {
+		token = u.User.Username()
+	}
+
+	if len(token) == 0 {
 		err = fmt.Errorf("missing token parameter in loggly endpoint: %s", u)
 	}
+
 	return
 }
 
-func extractPEN(u *url.URL, q url.Values) (pen string) {
-	if pen = q.Get("PEN"); len(pen) == 0 {
+func extractPEN(u *url.URL) (pen string) {
+	if u.User != nil {
+		pen, _ = u.User.Password()
+	}
+
+	if len(pen) == 0 {
 		pen = "41058"
 	}
+
 	return
 }
 

--- a/lib/loggly/writer.go
+++ b/lib/loggly/writer.go
@@ -1,0 +1,134 @@
+package loggly
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/segmentio/ecs-logs/lib"
+	"github.com/segmentio/ecs-logs/lib/syslog"
+)
+
+func NewWriter(group string, stream string) (w ecslogs.Writer, err error) {
+	var endpoint string
+	var protocol string
+	var address string
+	var token string
+	var pen string
+	var tags string
+
+	if endpoint, err = getEndpoint(); err != nil {
+		return
+	}
+
+	if protocol, address, token, pen, tags, err = parseEndpoint(endpoint, group, stream); err != nil {
+		return
+	}
+
+	return syslog.DialWriter(syslog.WriterConfig{
+		Network:    protocol,
+		Address:    address,
+		Template:   fmt.Sprintf("<{{.PRIVAL}}>1 {{.TIMESTAMP}} {{.HOSTNAME}} {{.GROUP}} {{.PROCID}} {{.MSGID}} [%s@%s %s] {{.MSG}}", token, pen, tags),
+		TimeFormat: "2006-01-02T15:04:05.999Z07:00",
+		TLS: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	})
+}
+
+func getEndpoint() (endpoint string, err error) {
+	var token string
+
+	if endpoint = os.Getenv("LOGGLY_URL"); len(endpoint) != 0 {
+		return
+	}
+
+	if token = os.Getenv("LOGGLY_TOKEN"); len(token) != 0 {
+		endpoint = "tls://logs-01.loggly.com:6514/?token=" + url.QueryEscape(token)
+		return
+	}
+
+	err = fmt.Errorf("missing LOGGLY_URL or LOGGLY_TOKEN environment variable")
+	return
+}
+
+func parseEndpoint(endpoint string, group string, stream string) (protocol string, address string, token string, pen string, tags string, err error) {
+	var u *url.URL
+	var q url.Values
+
+	if u, err = url.Parse(endpoint); err != nil {
+		err = fmt.Errorf("invalid loggly endpoint, %s: %s", err, endpoint)
+		return
+	}
+
+	if q, err = url.ParseQuery(u.RawQuery); err != nil {
+		err = fmt.Errorf("invalid query string in loggly endpoint, %s: %s", err, endpoint)
+		return
+	}
+
+	if protocol, err = extractProtocol(u); err != nil {
+		return
+	}
+
+	if address, err = extractAddress(u); err != nil {
+		return
+	}
+
+	if token, err = extractToken(u, q); err != nil {
+		return
+	}
+
+	pen = extractPEN(u, q)
+	tags = extractTags(u, q, group, stream)
+	return
+}
+
+func extractProtocol(u *url.URL) (protocol string, err error) {
+	switch u.Scheme {
+	case "tcp", "tls":
+		protocol = u.Scheme
+	case "":
+		err = fmt.Errorf("missing protocol in loggly endpoint: %s", u)
+	default:
+		err = fmt.Errorf("unsupported protocol in loggly endpoint, must be one of 'tcp' or 'tls': %s", u)
+	}
+	return
+}
+
+func extractAddress(u *url.URL) (address string, err error) {
+	if len(u.Host) == 0 {
+		err = fmt.Errorf("missing host in loggly endpoint: %s", u)
+	} else {
+		address = u.Host
+	}
+	return
+}
+
+func extractToken(u *url.URL, q url.Values) (token string, err error) {
+	if token = q.Get("token"); len(token) == 0 {
+		err = fmt.Errorf("missing token parameter in loggly endpoint: %s", u)
+	}
+	return
+}
+
+func extractPEN(u *url.URL, q url.Values) (pen string) {
+	if pen = q.Get("PEN"); len(pen) == 0 {
+		pen = "41058"
+	}
+	return
+}
+
+func extractTags(u *url.URL, q url.Values, group string, stream string) string {
+	tags := q["tag"]
+	list := make([]string, 0, len(tags)+2)
+	list = append(list, group, stream)
+	list = append(list, tags...)
+
+	for i, tag := range list {
+		list[i] = fmt.Sprintf("tag=%#v", tag)
+	}
+
+	return strings.Join(list, " ")
+}

--- a/lib/message.go
+++ b/lib/message.go
@@ -50,10 +50,10 @@ type Message struct {
 	File    string    `json:"file,omitempty"`
 	ID      string    `json:"id,omitempty"`
 	Host    string    `json:"host,omitempty"`
-	Group   string    `json:"group"`
-	Stream  string    `json:"stream"`
-	Content string    `json:"content"`
-	Time    time.Time `json:"time"`
+	Group   string    `json:"group,omitempty"`
+	Stream  string    `json:"stream,omitempty"`
+	Content string    `json:"content,omitempty"`
+	Time    time.Time `json:"time,omitempty"`
 }
 
 func (m Message) String() string {

--- a/lib/message.go
+++ b/lib/message.go
@@ -3,41 +3,8 @@ package ecslogs
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"time"
 )
-
-type MessageReader interface {
-	ReadMessage() (Message, error)
-}
-
-type MessageReadCloser interface {
-	io.Closer
-
-	MessageReader
-}
-
-type MessageWriter interface {
-	WriteMessage(Message) error
-}
-
-type MessageWriteCloser interface {
-	io.Closer
-
-	MessageWriter
-}
-
-type MessageBatchWriter interface {
-	MessageWriter
-
-	WriteMessageBatch([]Message) error
-}
-
-type MessageBatchWriteCloser interface {
-	io.Closer
-
-	MessageBatchWriter
-}
 
 type Message struct {
 	Level   Level     `json:"level"`
@@ -63,61 +30,4 @@ func (m Message) String() string {
 func (m Message) Format(f fmt.State, _ rune) {
 	b, _ := json.Marshal(m)
 	f.Write(b)
-}
-
-func NewMessageEncoder(w io.Writer) MessageBatchWriteCloser {
-	return messageEncoder{
-		j: json.NewEncoder(w),
-		w: w,
-	}
-}
-
-type messageEncoder struct {
-	j *json.Encoder
-	w io.Writer
-}
-
-func (e messageEncoder) Close() (err error) {
-	if c, ok := e.w.(io.Closer); ok {
-		err = c.Close()
-	}
-	return
-}
-
-func (e messageEncoder) WriteMessage(msg Message) (err error) {
-	err = e.j.Encode(msg)
-	return
-}
-
-func (e messageEncoder) WriteMessageBatch(batch []Message) (err error) {
-	for _, msg := range batch {
-		if err = e.WriteMessage(msg); err != nil {
-			return
-		}
-	}
-	return
-}
-
-func NewMessageDecoder(r io.Reader) MessageReadCloser {
-	return messageDecoder{
-		j: json.NewDecoder(r),
-		r: r,
-	}
-}
-
-type messageDecoder struct {
-	j *json.Decoder
-	r io.Reader
-}
-
-func (d messageDecoder) Close() (err error) {
-	if c, ok := d.r.(io.Closer); ok {
-		err = c.Close()
-	}
-	return
-}
-
-func (d messageDecoder) ReadMessage() (msg Message, err error) {
-	err = d.j.Decode(&msg)
-	return
 }

--- a/lib/message.go
+++ b/lib/message.go
@@ -40,6 +40,16 @@ type MessageBatchWriteCloser interface {
 }
 
 type Message struct {
+	Level   Level     `json:"level"`
+	PID     int       `json:"pid,omitempty"`
+	UID     int       `json:"uid,omitempty"`
+	GID     int       `json:"gid,omitempty"`
+	Errno   int       `json:"errno,omitempty"`
+	Line    int       `json:"line,omitempty"`
+	Func    string    `json:"func,omitempty"`
+	File    string    `json:"file,omitempty"`
+	ID      string    `json:"id,omitempty"`
+	Host    string    `json:"host,omitempty"`
 	Group   string    `json:"group"`
 	Stream  string    `json:"stream"`
 	Content string    `json:"content"`

--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -51,12 +51,10 @@ func TestMessageEncoderDecover(t *testing.T) {
 	go func() {
 		if err := e.WriteMessageBatch(batch); err != nil {
 			t.Error(err)
-			return
 		}
 
 		if err := e.Close(); err != nil {
 			t.Error(err)
-			return
 		}
 	}()
 

--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -17,7 +17,7 @@ func TestMessageString(t *testing.T) {
 		Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
 	}
 
-	const ref = `{"level":6,"group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456789Z"}`
+	const ref = `{"level":"INFO","group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456789Z"}`
 
 	if s := m.String(); s != ref {
 		t.Errorf("invalid string representation of the message:\n - expected: %s\n - found:    %s", ref, s)

--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -10,13 +10,14 @@ import (
 
 func TestMessageString(t *testing.T) {
 	m := Message{
+		Level:   INFO,
 		Group:   "abc",
 		Stream:  "0123456789",
 		Content: "Hello World!",
 		Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
 	}
 
-	const ref = `{"group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456789Z"}`
+	const ref = `{"level":6,"group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456789Z"}`
 
 	if s := m.String(); s != ref {
 		t.Errorf("invalid string representation of the message:\n - expected: %s\n - found:    %s", ref, s)
@@ -26,12 +27,14 @@ func TestMessageString(t *testing.T) {
 func TestMessageEncoderDecover(t *testing.T) {
 	batch := []Message{
 		Message{
+			Level:   INFO,
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "Hello World!",
 			Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
 		},
 		Message{
+			Level:   INFO,
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "How are you doing?",
@@ -85,12 +88,14 @@ func TestMessageEncoderDecover(t *testing.T) {
 func TestMessageEncoderWriteMessageBatchError(t *testing.T) {
 	batch := []Message{
 		Message{
+			Level:   INFO,
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "Hello World!",
 			Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
 		},
 		Message{
+			Level:   INFO,
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "How are you doing?",

--- a/lib/reader.go
+++ b/lib/reader.go
@@ -1,0 +1,36 @@
+package ecslogs
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Reader interface {
+	io.Closer
+
+	ReadMessage() (Message, error)
+}
+
+func NewMessageDecoder(r io.Reader) Reader {
+	return decoder{
+		j: json.NewDecoder(r),
+		r: r,
+	}
+}
+
+type decoder struct {
+	j *json.Decoder
+	r io.Reader
+}
+
+func (d decoder) Close() (err error) {
+	if c, ok := d.r.(io.Closer); ok {
+		err = c.Close()
+	}
+	return
+}
+
+func (d decoder) ReadMessage() (msg Message, err error) {
+	err = d.j.Decode(&msg)
+	return
+}

--- a/lib/source.go
+++ b/lib/source.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Source interface {
-	Open() (MessageReadCloser, error)
+	Open() (Reader, error)
 }
 
-type SourceFunc func() (MessageReadCloser, error)
+type SourceFunc func() (Reader, error)
 
-func (f SourceFunc) Open() (MessageReadCloser, error) {
+func (f SourceFunc) Open() (Reader, error) {
 	return f()
 }
 
@@ -51,7 +51,7 @@ func SourcesAvailable() (sources []string) {
 var (
 	srcmtx sync.RWMutex
 	srcmap = map[string]Source{
-		"stdin": SourceFunc(func() (MessageReadCloser, error) {
+		"stdin": SourceFunc(func() (Reader, error) {
 			return NewMessageDecoder(os.Stdin), nil
 		}),
 	}

--- a/lib/source.go
+++ b/lib/source.go
@@ -35,6 +35,19 @@ func GetSource(name string) (source Source) {
 	return
 }
 
+func GetSources(names ...string) (sources []Source) {
+	if len(names) != 0 {
+		sources = make([]Source, 0, len(names))
+
+		for _, name := range names {
+			if source := GetSource(name); source != nil {
+				sources = append(sources, source)
+			}
+		}
+	}
+	return
+}
+
 func SourcesAvailable() (sources []string) {
 	srcmtx.RLock()
 	sources = make([]string, 0, len(srcmap))

--- a/lib/source.go
+++ b/lib/source.go
@@ -36,15 +36,14 @@ func GetSource(name string) (source Source) {
 }
 
 func GetSources(names ...string) (sources []Source) {
-	if len(names) != 0 {
-		sources = make([]Source, 0, len(names))
+	sources = make([]Source, 0, len(names))
 
-		for _, name := range names {
-			if source := GetSource(name); source != nil {
-				sources = append(sources, source)
-			}
+	for _, name := range names {
+		if source := GetSource(name); source != nil {
+			sources = append(sources, source)
 		}
 	}
+
 	return
 }
 

--- a/lib/stream.go
+++ b/lib/stream.go
@@ -18,6 +18,7 @@ type StreamLimits struct {
 	MaxCount int
 	MaxBytes int
 	MaxTime  time.Duration
+	Force    bool
 }
 
 func NewStream(name string, now time.Time) *Stream {
@@ -57,6 +58,10 @@ func (stream *Stream) Flush(limits StreamLimits, now time.Time) []Message {
 	}
 
 	if now.Sub(stream.flushedOn) >= limits.MaxTime {
+		return stream.flushDueToTimeLimit(now)
+	}
+
+	if limits.Force {
 		return stream.flushDueToTimeLimit(now)
 	}
 

--- a/lib/syslog/init.go
+++ b/lib/syslog/init.go
@@ -1,0 +1,8 @@
+package syslog
+
+import "github.com/segmentio/ecs-logs/lib"
+
+func init() {
+	ecslogs.RegisterSource("syslog", ecslogs.SourceFunc(NewMessageReader))
+	ecslogs.RegisterDestination("syslog", ecslogs.DestinationFunc(NewMessageBatchWriter))
+}

--- a/lib/syslog/init.go
+++ b/lib/syslog/init.go
@@ -3,5 +3,5 @@ package syslog
 import "github.com/segmentio/ecs-logs/lib"
 
 func init() {
-	ecslogs.RegisterDestination("syslog", ecslogs.DestinationFunc(NewMessageBatchWriter))
+	ecslogs.RegisterDestination("syslog", ecslogs.DestinationFunc(NewWriter))
 }

--- a/lib/syslog/init.go
+++ b/lib/syslog/init.go
@@ -3,6 +3,5 @@ package syslog
 import "github.com/segmentio/ecs-logs/lib"
 
 func init() {
-	ecslogs.RegisterSource("syslog", ecslogs.SourceFunc(NewMessageReader))
 	ecslogs.RegisterDestination("syslog", ecslogs.DestinationFunc(NewMessageBatchWriter))
 }

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -57,24 +57,21 @@ func DialWriter(config WriterConfig) (w ecslogs.Writer, err error) {
 
 	if len(config.Network) != 0 {
 		netopts = []string{config.Network}
-	} else {
+	} else if len(config.Address) == 0 || strings.HasPrefix(config.Address, "/") {
 		// When starting with a '/' we assume it's gonna be a file path,
 		// otherwise we fallback to trying a TLS connection so we don't
 		// implicitly send logs over an unsecured link.
-		if len(config.Address) == 0 || strings.HasPrefix(config.Address, "/") {
-			config.Network = "unix"
-			netopts = []string{"unixgram", "unix"}
-		} else {
-			netopts = []string{"tls"}
-		}
+		config.Network = "unix"
+		netopts = []string{"unixgram", "unix"}
+	} else {
+		netopts = []string{"tls"}
 	}
 
 	if len(config.Address) != 0 {
 		addropts = []string{config.Address}
 	} else if strings.HasPrefix(config.Network, "unix") {
 		// This was copied from the standard log/syslog package, they do the same
-		// and try to guess at runtime where and what kind of socket syslogd is
-		// using.
+		// and try to guess at runtime which socket syslogd is using.
 		addropts = []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
 	} else {
 		// The config doesn't point to a unix domain socket, falling back to trying

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -26,6 +26,7 @@ type WriterConfig struct {
 	Address    string
 	Template   string
 	TimeFormat string
+	Tag        string
 	TLS        *tls.Config
 }
 
@@ -104,6 +105,7 @@ type writerConfig struct {
 	backend    io.Writer
 	template   string
 	timeFormat string
+	tag        string
 }
 
 func newWriter(config writerConfig) *writer {
@@ -182,6 +184,7 @@ func (w *writer) write(msg ecslogs.Message) (err error) {
 		STREAM:    msg.Stream,
 		MSG:       msg.Content,
 		TIMESTAMP: msg.Time.Format(w.timeFormat),
+		TAG:       w.tag,
 	}
 
 	if len(m.HOSTNAME) == 0 {
@@ -223,6 +226,7 @@ type message struct {
 	MSGID     string
 	GROUP     string
 	STREAM    string
+	TAG       string
 	MSG       string
 	SOURCE    string
 	TIMESTAMP string

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -1,0 +1,153 @@
+package syslog
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/segmentio/ecs-logs/lib"
+)
+
+const (
+	DefaultFormat = "<{{.PRIVAL}}>{{.TIMESTAMP}} {{.GROUP}}[{{.STREAM}}]: {{.MSG}}"
+)
+
+func NewWriterTemplate(format string) *template.Template {
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
+	}
+	t := template.New("syslog")
+	template.Must(t.Parse(format))
+	return t
+}
+
+func NewMessageBatchWriter(group string, stream string) (ecslogs.MessageBatchWriteCloser, error) {
+	return DialWriter("", "", nil)
+}
+
+func DialWriter(network string, address string, template *template.Template) (w ecslogs.MessageBatchWriteCloser, err error) {
+	var timeFormat string
+	var netopts []string
+	var addropts []string
+	var conn net.Conn
+
+	if len(network) != 0 {
+		netopts = []string{network}
+		addropts = []string{address}
+		timeFormat = "2006-01-02T15:04:05.999Z07:00"
+	} else {
+		netopts = []string{"unixgram", "unix"}
+		addropts = []string{"/dev/log", "/var/run/syslog", "/var/run/log"}
+		timeFormat = time.Stamp
+	}
+
+connect:
+	for _, n := range netopts {
+		for _, a := range addropts {
+			if conn, err = net.Dial(n, a); err == nil {
+				break connect
+			}
+		}
+	}
+
+	if err != nil {
+		return
+	}
+
+	w = NewWriter(conn, template, timeFormat)
+	return
+}
+
+func NewWriter(w io.Writer, t *template.Template, timeFormat string) ecslogs.MessageBatchWriteCloser {
+	if t == nil {
+		t = NewWriterTemplate(DefaultFormat)
+	}
+	c, _ := w.(io.Closer)
+	return syslogWriter{
+		c: c,
+		t: t,
+		b: bufio.NewWriter(w),
+		f: timeFormat,
+	}
+}
+
+type syslogWriter struct {
+	c io.Closer
+	b *bufio.Writer
+	t *template.Template
+	f string
+}
+
+func (w syslogWriter) Close() (err error) {
+	if err = w.b.Flush(); err != nil {
+		return
+	}
+
+	if w.c != nil {
+		err = w.c.Close()
+	}
+
+	return
+}
+
+func (w syslogWriter) WriteMessageBatch(batch []ecslogs.Message) (err error) {
+	for _, msg := range batch {
+		if err = w.WriteMessage(msg); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (w syslogWriter) WriteMessage(msg ecslogs.Message) (err error) {
+	m := syslogMessage{
+		PRIVAL:    int(msg.Level),
+		HOSTNAME:  msg.Host,
+		MSGID:     msg.ID,
+		GROUP:     msg.Group,
+		STREAM:    msg.Stream,
+		MSG:       msg.Content,
+		TIMESTAMP: msg.Time.Format(w.f),
+	}
+
+	if len(m.HOSTNAME) == 0 {
+		m.HOSTNAME = "-"
+	}
+
+	if len(m.MSGID) == 0 {
+		m.MSGID = "-"
+	}
+
+	if msg.PID == 0 {
+		m.PROCID = "-"
+	} else {
+		m.PROCID = strconv.Itoa(msg.PID)
+	}
+
+	if len(msg.File) != 0 || len(msg.Func) != 0 {
+		m.SOURCE = fmt.Sprintf("%s:%s:%d", msg.File, msg.Func, msg.Line)
+	}
+
+	if err = w.t.Execute(w.b, m); err == nil {
+		err = w.b.Flush()
+	}
+
+	return
+}
+
+type syslogMessage struct {
+	PRIVAL    int
+	HOSTNAME  string
+	PROCID    string
+	MSGID     string
+	GROUP     string
+	STREAM    string
+	MSG       string
+	SOURCE    string
+	TIMESTAMP string
+}

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -97,6 +97,7 @@ connect:
 		backend:    backend,
 		template:   config.Template,
 		timeFormat: config.TimeFormat,
+		tag:        config.Tag,
 	})
 	return
 }

--- a/lib/writer.go
+++ b/lib/writer.go
@@ -1,0 +1,47 @@
+package ecslogs
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Writer interface {
+	io.Closer
+
+	WriteMessage(Message) error
+
+	WriteMessageBatch([]Message) error
+}
+
+func NewMessageEncoder(w io.Writer) Writer {
+	return encoder{
+		j: json.NewEncoder(w),
+		w: w,
+	}
+}
+
+type encoder struct {
+	j *json.Encoder
+	w io.Writer
+}
+
+func (e encoder) Close() (err error) {
+	if c, ok := e.w.(io.Closer); ok {
+		err = c.Close()
+	}
+	return
+}
+
+func (e encoder) WriteMessage(msg Message) (err error) {
+	err = e.j.Encode(msg)
+	return
+}
+
+func (e encoder) WriteMessageBatch(batch []Message) (err error) {
+	for _, msg := range batch {
+		if err = e.WriteMessage(msg); err != nil {
+			return
+		}
+	}
+	return
+}


### PR DESCRIPTION
@segmentio/infra 

Hey guys, I put a little time into extending `ecs-logs`, here's the list of the changes:
- support for structured logs in CloudWatch (JSON)
- support for syslog as a destination
- support for loggly as a destination (via the syslog interface)
- support for multiple sources (fan in)
- support for multiple destinations (fan out)
- load more metadata from the journal (priority, hostname, ...)
- simpler type names

Please take a look and let me know if you would like to see anything changed.