### PR TITLE
Timestamp

### DIFF
--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -2,7 +2,6 @@ package cloudwatchlogs
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -112,13 +111,13 @@ func makeLogEvents(batch []ecslogs.Message) (events []*cloudwatchlogs.InputLogEv
 		if len(msg.Content) != 0 {
 			// Set the message properties to their zero-value so they are omitted when
 			// serialized to JSON by the String method.
-			timestamp := msg.Time
+			ts := msg.Time
 			msg.Group = ""
 			msg.Stream = ""
-			msg.Time = time.Time{}
+			msg.Time = 0
 			events = append(events, &cloudwatchlogs.InputLogEvent{
 				Message:   aws.String(msg.String()),
-				Timestamp: aws.Int64(aws.TimeUnixMilli(timestamp)),
+				Timestamp: aws.Int64(ts.Milliseconds()),
 			})
 		}
 	}

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -87,9 +87,9 @@ func (r reader) getInt(k string) (v int) {
 	return
 }
 
-func (r reader) getTime() (t time.Time) {
+func (r reader) getTime() (t ecslogs.Timestamp) {
 	if u, e := r.GetRealtimeUsec(); e == nil {
-		t = time.Unix(int64(u/1000000), int64((u%1000000)*1000))
+		t = ecslogs.MakeTimestamp(time.Unix(int64(u/1000000), int64((u%1000000)*1000)))
 	}
 	return
 }

--- a/lib/message.go
+++ b/lib/message.go
@@ -3,7 +3,6 @@ package ecslogs
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 )
 
 type Message struct {
@@ -20,7 +19,7 @@ type Message struct {
 	Group   string    `json:"group,omitempty"`
 	Stream  string    `json:"stream,omitempty"`
 	Content string    `json:"content,omitempty"`
-	Time    time.Time `json:"time,omitempty"`
+	Time    Timestamp `json:"time,omitempty"`
 }
 
 func (m Message) String() string {

--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -14,10 +14,10 @@ func TestMessageString(t *testing.T) {
 		Group:   "abc",
 		Stream:  "0123456789",
 		Content: "Hello World!",
-		Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
+		Time:    MakeTimestamp(time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC)),
 	}
 
-	const ref = `{"level":"INFO","group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456789Z"}`
+	const ref = `{"level":"INFO","group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456Z"}`
 
 	if s := m.String(); s != ref {
 		t.Errorf("invalid string representation of the message:\n - expected: %s\n - found:    %s", ref, s)
@@ -31,14 +31,14 @@ func TestMessageEncoderDecover(t *testing.T) {
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "Hello World!",
-			Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
+			Time:    MakeTimestamp(time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC)),
 		},
 		Message{
 			Level:   INFO,
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "How are you doing?",
-			Time:    time.Date(2016, 6, 13, 12, 24, 42, 123456789, time.UTC),
+			Time:    MakeTimestamp(time.Date(2016, 6, 13, 12, 24, 42, 123456789, time.UTC)),
 		},
 	}
 
@@ -90,14 +90,14 @@ func TestMessageEncoderWriteMessageBatchError(t *testing.T) {
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "Hello World!",
-			Time:    time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC),
+			Time:    MakeTimestamp(time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC)),
 		},
 		Message{
 			Level:   INFO,
 			Group:   "abc",
 			Stream:  "0123456789",
 			Content: "How are you doing?",
-			Time:    time.Date(2016, 6, 13, 12, 24, 42, 123456789, time.UTC),
+			Time:    MakeTimestamp(time.Date(2016, 6, 13, 12, 24, 42, 123456789, time.UTC)),
 		},
 	}
 

--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -2,6 +2,7 @@ package ecslogs
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"reflect"
 	"testing"
@@ -9,15 +10,16 @@ import (
 )
 
 func TestMessageString(t *testing.T) {
+	d := time.Date(2016, 6, 13, 12, 23, 42, 123456000, time.Local)
 	m := Message{
 		Level:   INFO,
 		Group:   "abc",
 		Stream:  "0123456789",
 		Content: "Hello World!",
-		Time:    MakeTimestamp(time.Date(2016, 6, 13, 12, 23, 42, 123456789, time.UTC)),
+		Time:    MakeTimestamp(d),
 	}
 
-	const ref = `{"level":"INFO","group":"abc","stream":"0123456789","content":"Hello World!","time":"2016-06-13T12:23:42.123456Z"}`
+	ref := fmt.Sprintf(`{"level":"INFO","group":"abc","stream":"0123456789","content":"Hello World!","time":"%s"}`, d.Format(time.RFC3339Nano))
 
 	if s := m.String(); s != ref {
 		t.Errorf("invalid string representation of the message:\n - expected: %s\n - found:    %s", ref, s)

--- a/lib/stream_test.go
+++ b/lib/stream_test.go
@@ -89,7 +89,7 @@ func TestStreamNotExpiredDueToMessages(t *testing.T) {
 		Group:   "abc",
 		Stream:  "0123456789",
 		Content: "Hello World!",
-		Time:    ts,
+		Time:    MakeTimestamp(ts),
 	}, ts)
 
 	if st.HasExpired(1*time.Second, ts.Add(2*time.Second)) {

--- a/lib/time.go
+++ b/lib/time.go
@@ -15,7 +15,7 @@ func ParseTimestamp(s string) (ts Timestamp, err error) {
 	var t time.Time
 
 	for _, format := range timeFormats {
-		if t, err = time.ParseInLocation(format, s, time.UTC); err == nil {
+		if t, err = time.Parse(format, s); err == nil {
 			ts = MakeTimestamp(t)
 			break
 		}
@@ -25,7 +25,6 @@ func ParseTimestamp(s string) (ts Timestamp, err error) {
 }
 
 func MakeTimestamp(t time.Time) Timestamp {
-	t = t.UTC()
 	return Timestamp(t.Unix()*1000000) + Timestamp(t.Nanosecond()/1000)
 }
 
@@ -53,14 +52,12 @@ func (ts Timestamp) Nanoseconds() int64 {
 	return int64(ts * 1000)
 }
 
-func (ts Timestamp) Time(tz *time.Location) time.Time {
-	t1 := time.Unix(ts.Seconds(), ts.Nanoseconds()%1000000000)
-	t2 := t1.In(tz)
-	return t2.Add(t1.Sub(t2))
+func (ts Timestamp) Time() time.Time {
+	return time.Unix(ts.Seconds(), ts.Nanoseconds()%1000000000)
 }
 
 func (ts Timestamp) Format(format string) string {
-	return ts.Time(time.UTC).Format(format)
+	return ts.Time().Format(format)
 }
 
 func (ts Timestamp) MarshalText() (b []byte, err error) {

--- a/lib/time.go
+++ b/lib/time.go
@@ -1,0 +1,90 @@
+package ecslogs
+
+import (
+	"strconv"
+	"time"
+)
+
+type Timestamp int64
+
+func Now() Timestamp {
+	return MakeTimestamp(time.Now())
+}
+
+func ParseTimestamp(s string) (ts Timestamp, err error) {
+	var t time.Time
+
+	for _, format := range timeFormats {
+		if t, err = time.ParseInLocation(format, s, time.UTC); err == nil {
+			ts = MakeTimestamp(t)
+			break
+		}
+	}
+
+	return
+}
+
+func MakeTimestamp(t time.Time) Timestamp {
+	t = t.UTC()
+	return Timestamp(t.Unix()*1000000) + Timestamp(t.Nanosecond()/1000)
+}
+
+func (ts Timestamp) GoString() string {
+	return "Timestamp(" + strconv.FormatInt(int64(ts), 10) + ")"
+}
+
+func (ts Timestamp) String() string {
+	return ts.Format("2006-01-02T15:04:05.999999Z07:00")
+}
+
+func (ts Timestamp) Seconds() int64 {
+	return int64(ts / 1000000)
+}
+
+func (ts Timestamp) Milliseconds() int64 {
+	return int64(ts / 1000)
+}
+
+func (ts Timestamp) Microseconds() int64 {
+	return int64(ts)
+}
+
+func (ts Timestamp) Nanoseconds() int64 {
+	return int64(ts * 1000)
+}
+
+func (ts Timestamp) Time(tz *time.Location) time.Time {
+	t1 := time.Unix(ts.Seconds(), ts.Nanoseconds()%1000000000)
+	t2 := t1.In(tz)
+	return t2.Add(t1.Sub(t2))
+}
+
+func (ts Timestamp) Format(format string) string {
+	return ts.Time(time.UTC).Format(format)
+}
+
+func (ts Timestamp) MarshalText() (b []byte, err error) {
+	b = []byte(ts.String())
+	return
+}
+
+func (ts *Timestamp) UnmarshalText(b []byte) (err error) {
+	*ts, err = ParseTimestamp(string(b))
+	return
+}
+
+var (
+	timeFormats = []string{
+		time.RFC3339Nano,
+		"2006-01-02T15:04:05.999999Z07:00", // RFC3338 micro
+		"2006-01-02T15:04:05.999Z07:00",    // RFC3338 milli
+		time.RFC3339,
+	}
+)
+
+const (
+	secondsPerMinute       = 60
+	secondsPerHour         = 60 * 60
+	secondsPerDay          = 24 * secondsPerHour
+	unixToInternal   int64 = (1969*365 + 1969/4 - 1969/100 + 1969/400) * secondsPerDay
+)

--- a/lib/time.go
+++ b/lib/time.go
@@ -81,10 +81,3 @@ var (
 		time.RFC3339,
 	}
 )
-
-const (
-	secondsPerMinute       = 60
-	secondsPerHour         = 60 * 60
-	secondsPerDay          = 24 * secondsPerHour
-	unixToInternal   int64 = (1969*365 + 1969/4 - 1969/100 + 1969/400) * secondsPerDay
-)

--- a/lib/time_test.go
+++ b/lib/time_test.go
@@ -1,0 +1,23 @@
+package ecslogs
+
+import "testing"
+
+func TestParseTimestampSuccess(t *testing.T) {
+	tests := []struct {
+		t Timestamp
+		s string
+	}{
+		{
+			t: Timestamp(1467136754000000),
+			s: "2016-06-28T17:59:14Z",
+		},
+	}
+
+	for _, test := range tests {
+		if ts, err := ParseTimestamp(test.s); err != nil {
+			t.Errorf("%s: %s", test.s, err)
+		} else if ts != test.t {
+			t.Errorf("%s: %s %#v %#v", test.s, ts, ts, test.t)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -151,8 +151,8 @@ func read(r ecslogs.Reader, c chan<- ecslogs.Message, counter *int32, hostname s
 			msg.Host = hostname
 		}
 
-		if msg.Time == (time.Time{}) {
-			msg.Time = time.Now()
+		if msg.Time == 0 {
+			msg.Time = ecslogs.Now()
 		}
 
 		c <- msg


### PR DESCRIPTION
@segmentio/infra 

The default JSON encoder doesn't omit fields tagged with `omitempty` if they are not base types, `time.Time` is a struct so it was getting serialized to CloudWatchLogs which is redundant with the `Timestamp` field.

I replaced the use of `time.Time` in the `ecslogs.Message.Time` field with a `ecslogs.Timestamp` type which represents a microsecond precision timestamp and can be set to zero so it doesn't get serialized in the CloudWatchLogs events.

Please take a look and let me know if this is good to go!