### PR TITLE
fix cloudwatchlogs implementation

### DIFF
--- a/lib/cloudwatchlogs/client.go
+++ b/lib/cloudwatchlogs/client.go
@@ -55,6 +55,10 @@ func (c *client) Open(group string, stream string) (w ecslogs.Writer, err error)
 	return
 }
 
+func (c *client) Close(group string, stream string) {
+	c.remove(group, stream)
+}
+
 func (c *client) get(group string, stream string) (w *writer) {
 	key := joinGroupStream(group, stream)
 	c.wmtx.Lock()

--- a/lib/cloudwatchlogs/client.go
+++ b/lib/cloudwatchlogs/client.go
@@ -1,0 +1,159 @@
+package cloudwatchlogs
+
+import (
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/segmentio/ecs-logs/lib"
+)
+
+type client struct {
+	cmtx   sync.Mutex
+	client *cloudwatchlogs.CloudWatchLogs
+
+	wmtx    sync.Mutex
+	writers map[string]*writer
+}
+
+func newClient() *client {
+	return &client{
+		writers: make(map[string]*writer, 100),
+	}
+}
+
+func (c *client) Open(group string, stream string) (w ecslogs.Writer, err error) {
+	var client *cloudwatchlogs.CloudWatchLogs
+	var token string
+	var writer = c.get(group, stream)
+
+	w = writer
+
+	writer.mutex.Lock()
+	defer writer.mutex.Unlock()
+
+	if len(writer.token) != 0 {
+		// The writer already has a token, this means the log group and streams
+		// have been created for that writer already.
+		return
+	}
+
+	if client, err = c.getAwsClient(); err != nil {
+		return
+	}
+
+	if token, err = createGroupAndStream(client, group, stream); err != nil {
+		// Creating the log group or stream failed, this writer cannot be used.
+		delete(c.writers, joinGroupStream(group, stream))
+		return
+	}
+
+	writer.token = token
+	return
+}
+
+func (c *client) get(group string, stream string) (w *writer) {
+	key := joinGroupStream(group, stream)
+	c.wmtx.Lock()
+
+	if w = c.writers[key]; w == nil {
+		w = &writer{
+			group:  group,
+			stream: stream,
+			parent: c,
+		}
+		c.writers[key] = w
+	}
+
+	c.wmtx.Unlock()
+	return
+}
+
+func (c *client) remove(group string, stream string) {
+	key := joinGroupStream(group, stream)
+	c.wmtx.Lock()
+	delete(c.writers, key)
+	c.wmtx.Unlock()
+}
+
+func (c *client) getAwsClient() (client *cloudwatchlogs.CloudWatchLogs, err error) {
+	c.cmtx.Lock()
+	defer c.cmtx.Unlock()
+
+	if client = c.client; client == nil {
+		if client, err = openAwsClient(); err != nil {
+			return
+		}
+		c.client = client
+	}
+
+	return
+}
+
+func openAwsClient() (client *cloudwatchlogs.CloudWatchLogs, err error) {
+	var region string
+
+	if region, err = getAwsRegion(); err != nil {
+		return
+	}
+
+	client = cloudwatchlogs.New(session.New(&aws.Config{
+		Region: aws.String(region),
+	}))
+	return
+}
+
+func createGroupAndStream(client *cloudwatchlogs.CloudWatchLogs, group string, stream string) (token string, err error) {
+	var result *cloudwatchlogs.DescribeLogStreamsOutput
+
+	// Ignore failures on group and stream creation, describing the stream will
+	// fail later if the group doesn't exist. That way the group creation is
+	// idempotent.
+	client.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
+		LogGroupName: aws.String(group),
+	})
+	client.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
+		LogGroupName:  aws.String(group),
+		LogStreamName: aws.String(stream),
+	})
+
+	if result, err = client.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
+		Limit:               aws.Int64(1),
+		LogGroupName:        aws.String(group),
+		LogStreamNamePrefix: aws.String(stream),
+	}); err != nil {
+		// The AWS Go SDK doesn't export error types, this is the best hack I
+		// cloud find to check for this specific error type.
+		//
+		// The documentation says that we can only make 5 calls per second to
+		// this endpoint, but we need the sequence token in order to send events
+		// to streams that already exist.
+		//
+		// If we fail to fetch the stream description we still move on without
+		// a token and let the retry logic around PutLogEvents attempt to handle
+		// the issue.
+		if strings.HasPrefix(err.Error(), "ThrottlingException:") {
+			err = nil
+		}
+		return
+	}
+
+	if len(result.LogStreams) == 0 {
+		err = errDescribeLogStream
+		return
+	}
+
+	token = aws.StringValue(result.LogStreams[0].UploadSequenceToken)
+	return
+}
+
+func joinGroupStream(group string, stream string) string {
+	return group + "::" + stream
+}
+
+var (
+	errDescribeLogStream = errors.New("getting the log stream description failed")
+)

--- a/lib/cloudwatchlogs/init.go
+++ b/lib/cloudwatchlogs/init.go
@@ -3,5 +3,5 @@ package cloudwatchlogs
 import "github.com/segmentio/ecs-logs/lib"
 
 func init() {
-	ecslogs.RegisterDestination("cloudwatchlogs", ecslogs.DestinationFunc(NewWriter))
+	ecslogs.RegisterDestination("cloudwatchlogs", newClient())
 }

--- a/lib/cloudwatchlogs/region.go
+++ b/lib/cloudwatchlogs/region.go
@@ -2,8 +2,8 @@ package cloudwatchlogs
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"os"
 	"sync"
 )
 
@@ -12,6 +12,9 @@ type document struct {
 }
 
 func getAwsRegion() (region string, err error) {
+	var res *http.Response
+	var doc document
+
 	if region = __getAwsRegion(); len(region) != 0 {
 		return
 	}
@@ -23,10 +26,13 @@ func getAwsRegion() (region string, err error) {
 		return
 	}
 
-	fmt.Println("fetching AWS region from EC2 instance metadata...")
+	if region = os.Getenv("AWS_REGION"); len(region) != 0 {
+		goto saveRegion
+	}
 
-	var res *http.Response
-	var doc document
+	if region = os.Getenv("AWS_DEFAULT_REGION"); len(region) != 0 {
+		goto saveRegion
+	}
 
 	if res, err = http.Get("http://169.254.169.254/latest/dynamic/instance-identity/document"); err != nil {
 		return
@@ -38,8 +44,8 @@ func getAwsRegion() (region string, err error) {
 	}
 
 	region = doc.Region
+saveRegion:
 	regvar = region
-	fmt.Println("the AWS region is", region)
 	return
 }
 

--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -2,7 +2,6 @@ package cloudwatchlogs
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -102,10 +101,8 @@ func (w *writer) WriteMessageBatch(batch []ecslogs.Message) (err error) {
 
 func parseInvalidSequenceTokenException(err error) (token *string) {
 	msg := err.Error()
-	fmt.Println("<<<", msg)
 
 	if !strings.HasPrefix(msg, "InvalidSequenceTokenException:") {
-		fmt.Println("no prefix")
 		return
 	}
 
@@ -116,12 +113,10 @@ func parseInvalidSequenceTokenException(err error) (token *string) {
 	parts := strings.Split(msg, ":")
 
 	if len(parts) < 3 {
-		fmt.Println("bad parts count:", len(parts))
 		return
 	}
 
 	s := strings.TrimSpace(parts[2])
-	fmt.Println(">>>", s)
 	token = &s
 	return
 }

--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -1,124 +1,131 @@
 package cloudwatchlogs
 
 import (
+	"errors"
 	"fmt"
+	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/segmentio/ecs-logs/lib"
 )
 
-func NewWriter(group string, stream string) (w ecslogs.Writer, err error) {
-	var region string
-
-	if region, err = getAwsRegion(); err != nil {
-		return
-	}
-
-	w = writer{
-		group:  group,
-		stream: stream,
-		client: cloudwatchlogs.New(session.New(&aws.Config{
-			Region: aws.String(region),
-		})),
-	}
-	return
-}
-
 type writer struct {
+	mutex  sync.Mutex
 	group  string
 	stream string
-	client *cloudwatchlogs.CloudWatchLogs
+	token  string
+	parent *client
 }
 
-func (w writer) Close() error {
+func (w *writer) Close() error {
 	return nil
 }
 
-func (w writer) WriteMessage(msg ecslogs.Message) error {
+func (w *writer) WriteMessage(msg ecslogs.Message) error {
 	return w.WriteMessageBatch([]ecslogs.Message{msg})
 }
 
-func (w writer) WriteMessageBatch(batch []ecslogs.Message) (err error) {
-	var stream *cloudwatchlogs.LogStream
-
-	w.ensureCreateGroup()
-	w.ensureCreateStream()
-
-	if stream, err = w.fetchStream(); err != nil {
+func (w *writer) WriteMessageBatch(batch []ecslogs.Message) (err error) {
+	if len(batch) == 0 {
 		return
 	}
 
-	return w.writeBatch(stream, batch)
-}
+	var token *string
+	var result *cloudwatchlogs.PutLogEventsOutput
+	var events = make([]*cloudwatchlogs.InputLogEvent, len(batch))
 
-func (w writer) ensureCreateGroup() {
-	w.client.CreateLogGroup(&cloudwatchlogs.CreateLogGroupInput{
-		LogGroupName: aws.String(w.group),
-	})
-	return
-}
-
-func (w writer) ensureCreateStream() {
-	w.client.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
-		LogGroupName:  aws.String(w.group),
-		LogStreamName: aws.String(w.stream),
-	})
-	return
-}
-
-func (w writer) fetchStream() (stream *cloudwatchlogs.LogStream, err error) {
-	var streams *cloudwatchlogs.DescribeLogStreamsOutput
-
-	if streams, err = w.client.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
-		LogGroupName:        aws.String(w.group),
-		LogStreamNamePrefix: aws.String(w.stream),
-		Limit:               aws.Int64(1),
-	}); err != nil {
-		return
-	}
-
-	if len(streams.LogStreams) == 0 {
-		err = fmt.Errorf("failed to fetch log stream info from cloud watch logs (%s: stream not found)", w.stream)
-		return
-	}
-
-	stream = streams.LogStreams[0]
-	return
-}
-
-func (w writer) writeBatch(stream *cloudwatchlogs.LogStream, batch []ecslogs.Message) (err error) {
-	var events []*cloudwatchlogs.InputLogEvent
-
-	if events = makeLogEvents(batch); len(events) == 0 {
-		return
-	}
-
-	_, err = w.client.PutLogEvents(&cloudwatchlogs.PutLogEventsInput{
-		LogEvents:     events,
-		LogGroupName:  aws.String(w.group),
-		LogStreamName: aws.String(w.stream),
-		SequenceToken: stream.UploadSequenceToken,
-	})
-	return
-}
-
-func makeLogEvents(batch []ecslogs.Message) (events []*cloudwatchlogs.InputLogEvent) {
-	events = make([]*cloudwatchlogs.InputLogEvent, 0, len(batch))
-
-	for _, msg := range batch {
+	for i, msg := range batch {
 		// Set the message properties to their zero-value so they are omitted when
 		// serialized to JSON by the String method.
 		ts := msg.Time
 		msg.Group = ""
 		msg.Stream = ""
 		msg.Time = 0
-		events = append(events, &cloudwatchlogs.InputLogEvent{
+		events[i] = &cloudwatchlogs.InputLogEvent{
 			Message:   aws.String(msg.String()),
 			Timestamp: aws.Int64(ts.Milliseconds()),
-		})
+		}
 	}
 
+	// Because of the logic imposed by the AWS API we can only submit one upload
+	// request per log stream at a time due to the sequence token being unique
+	// and usable only once.
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if w.parent == nil {
+		// Another goroutine has invalidated this writer, giving up.
+		err = errInvalidWriter
+		return
+	}
+
+	if len(w.token) != 0 {
+		token = aws.String(w.token)
+	}
+
+	for attempt := 1; true; attempt++ {
+		if result, err = w.parent.client.PutLogEvents(&cloudwatchlogs.PutLogEventsInput{
+			LogEvents:     events,
+			LogGroupName:  aws.String(w.group),
+			LogStreamName: aws.String(w.stream),
+			SequenceToken: token,
+		}); err == nil {
+			break
+		}
+
+		// The AWS Go SDK doesn't expose the error type but does return the
+		// token in the error message so we attempt to extract it from there
+		// and let the retry logic resubmit the event batch.
+		//
+		// See: https://forums.aws.amazon.com/message.jspa?messageID=676912
+		if token = parseInvalidSequenceTokenException(err); attempt < 3 && token != nil {
+			err = nil
+			continue
+		}
+
+		// The documentation says we have to provide the sequence token when
+		// uploading events to CloudWatchLogs, if an error is returned here
+		// it's likely the token we have is either invalid or something worse
+		// happened.
+		// We remove the writer from it's parent client so a new writer will
+		// be created.
+		w.parent.remove(w.group, w.stream)
+		w.parent = nil
+		return
+	}
+
+	w.token = aws.StringValue(result.NextSequenceToken)
 	return
 }
+
+func parseInvalidSequenceTokenException(err error) (token *string) {
+	msg := err.Error()
+	fmt.Println("<<<", msg)
+
+	if !strings.HasPrefix(msg, "InvalidSequenceTokenException:") {
+		fmt.Println("no prefix")
+		return
+	}
+
+	if lines := strings.Split(msg, "\n"); len(lines) != 0 {
+		msg = lines[0]
+	}
+
+	parts := strings.Split(msg, ":")
+
+	if len(parts) < 3 {
+		fmt.Println("bad parts count:", len(parts))
+		return
+	}
+
+	s := strings.TrimSpace(parts[2])
+	fmt.Println(">>>", s)
+	token = &s
+	return
+}
+
+var (
+	errInvalidWriter = errors.New("the writer was invalidated by another goroutine")
+)

--- a/lib/destination.go
+++ b/lib/destination.go
@@ -8,6 +8,8 @@ import (
 
 type Destination interface {
 	Open(group string, stream string) (Writer, error)
+
+	Close(group string, stream string)
 }
 
 type DestinationFunc func(group string, stream string) (Writer, error)
@@ -15,6 +17,8 @@ type DestinationFunc func(group string, stream string) (Writer, error)
 func (f DestinationFunc) Open(group string, stream string) (Writer, error) {
 	return f(group, stream)
 }
+
+func (f DestinationFunc) Close(group string, stream string) {}
 
 func RegisterDestination(name string, destination Destination) {
 	dstmtx.Lock()

--- a/lib/group.go
+++ b/lib/group.go
@@ -31,7 +31,7 @@ func (group *Group) Name() string {
 
 func (group *Group) Add(msg Message, now time.Time) (stream *Stream) {
 	if stream = group.streams[msg.Stream]; stream == nil {
-		stream = NewStream(msg.Stream, now)
+		stream = NewStream(group.Name(), msg.Stream, now)
 		group.streams[msg.Stream] = stream
 	}
 
@@ -44,12 +44,14 @@ func (group *Group) HasExpired(timeout time.Duration, now time.Time) bool {
 	return len(group.streams) == 0 && now.Sub(group.updatedOn) >= timeout
 }
 
-func (group *Group) RemoveExpired(timeout time.Duration, now time.Time) {
+func (group *Group) RemoveExpired(timeout time.Duration, now time.Time) (streams []*Stream) {
 	for name, stream := range group.streams {
 		if stream.HasExpired(timeout, now) {
+			streams = append(streams, stream)
 			delete(group.streams, name)
 		}
 	}
+	return
 }
 
 func (group *Group) ForEach(f func(*Stream)) {

--- a/lib/store.go
+++ b/lib/store.go
@@ -22,12 +22,15 @@ func (store *Store) Add(msg Message, now time.Time) (group *Group, stream *Strea
 	return
 }
 
-func (store *Store) RemoveExpired(timeout time.Duration, now time.Time) {
+func (store *Store) RemoveExpired(timeout time.Duration, now time.Time) (streams []*Stream) {
 	for name, group := range store.groups {
+		streams = append(streams, group.RemoveExpired(timeout, now)...)
+
 		if group.HasExpired(timeout, now) {
 			delete(store.groups, name)
 		}
 	}
+	return
 }
 
 func (store *Store) ForEach(f func(*Group)) {

--- a/lib/stream.go
+++ b/lib/stream.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Stream struct {
+	group     string
 	name      string
 	bytes     int
 	messages  []Message
@@ -21,8 +22,9 @@ type StreamLimits struct {
 	Force    bool
 }
 
-func NewStream(name string, now time.Time) *Stream {
+func NewStream(group string, name string, now time.Time) *Stream {
 	return &Stream{
+		group:     group,
 		name:      name,
 		messages:  make([]Message, 0, 1000),
 		createdOn: now,
@@ -32,7 +34,11 @@ func NewStream(name string, now time.Time) *Stream {
 }
 
 func (stream *Stream) String() string {
-	return fmt.Sprintf("stream { name = %#v }", stream.Name())
+	return fmt.Sprintf("stream { group = %#v, name = %#v }", stream.Group(), stream.Name())
+}
+
+func (stream *Stream) Group() string {
+	return stream.group
 }
 
 func (stream *Stream) Name() string {

--- a/lib/stream_test.go
+++ b/lib/stream_test.go
@@ -57,7 +57,7 @@ func TestSplitMessageListHead(t *testing.T) {
 
 func TestStreamName(t *testing.T) {
 	ts := time.Now()
-	st := NewStream("0123456789", ts)
+	st := NewStream("A", "0123456789", ts)
 
 	if s := st.Name(); s != "0123456789" {
 		t.Error("invalid stream name:", s)
@@ -66,16 +66,16 @@ func TestStreamName(t *testing.T) {
 
 func TestStreamString(t *testing.T) {
 	ts := time.Now()
-	st := NewStream("0123456789", ts)
+	st := NewStream("A", "0123456789", ts)
 
-	if s := st.String(); s != `stream { name = "0123456789" }` {
+	if s := st.String(); s != `stream { group = "A", name = "0123456789" }` {
 		t.Error("invalid stream name:", s)
 	}
 }
 
 func TestStreamExpired(t *testing.T) {
 	ts := time.Now()
-	st := NewStream("0123456789", ts)
+	st := NewStream("A", "0123456789", ts)
 
 	if !st.HasExpired(1*time.Second, ts.Add(2*time.Second)) {
 		t.Error("new stream should be considered expired because it has no messages and wasn't updated recently")
@@ -84,9 +84,9 @@ func TestStreamExpired(t *testing.T) {
 
 func TestStreamNotExpiredDueToMessages(t *testing.T) {
 	ts := time.Now()
-	st := NewStream("0123456789", ts)
+	st := NewStream("A", "0123456789", ts)
 	st.Add(Message{
-		Group:   "abc",
+		Group:   "A",
 		Stream:  "0123456789",
 		Content: "Hello World!",
 		Time:    MakeTimestamp(ts),
@@ -99,7 +99,7 @@ func TestStreamNotExpiredDueToMessages(t *testing.T) {
 
 func TestStreamNotExpiredDueToTimeout(t *testing.T) {
 	ts := time.Now()
-	st := NewStream("0123456789", ts)
+	st := NewStream("A", "0123456789", ts)
 
 	if st.HasExpired(1*time.Second, ts) {
 		t.Error("streams that were updated recently should not be expired")


### PR DESCRIPTION
@segmentio/infra 

I've tracked down more of the rate limiting issues, there was actually no problem in the logic, the rate limitation was on the DescribeLogStreams call, the API supports only 5 per second globally...

This call is necessary to get the current upload token to a log stream, the first implementation I had was making a call for each stream before calling PutLogEvents so it could figure out what upload token it needed to send...

This PR introduces a more complex logic to maintain tokens in cache and only fetch them for the first batch of message sent or when an error occurs.
I also noticed that PutLogEvents does return an error containing the upload token when none is provided so I added logic to parse the error message and retry in that case.

Please take a look and let me know if anything needs to be changed.