### PR TITLE
sort message batches

### DIFF
--- a/lib/cloudwatchlogs/writer.go
+++ b/lib/cloudwatchlogs/writer.go
@@ -23,10 +23,10 @@ func (w *writer) Close() error {
 }
 
 func (w *writer) WriteMessage(msg ecslogs.Message) error {
-	return w.WriteMessageBatch([]ecslogs.Message{msg})
+	return w.WriteMessageBatch(ecslogs.MessageBatch{msg})
 }
 
-func (w *writer) WriteMessageBatch(batch []ecslogs.Message) (err error) {
+func (w *writer) WriteMessageBatch(batch ecslogs.MessageBatch) (err error) {
 	if len(batch) == 0 {
 		return
 	}

--- a/lib/event.go
+++ b/lib/event.go
@@ -38,24 +38,24 @@ type EventInfo struct {
 	Errors []EventError `json:"errors,omitempty"`
 }
 
-func (c EventInfo) Bytes() []byte {
-	b, _ := json.Marshal(c)
+func (e EventInfo) Bytes() []byte {
+	b, _ := json.Marshal(e)
 	return b
 }
 
-func (c EventInfo) String() string {
-	return string(c.Bytes())
+func (e EventInfo) String() string {
+	return string(e.Bytes())
 }
 
 type EventData map[string]interface{}
 
-func (c EventData) Bytes() []byte {
-	b, _ := json.Marshal(c)
+func (e EventData) Bytes() []byte {
+	b, _ := json.Marshal(e)
 	return b
 }
 
-func (c EventData) String() string {
-	return string(c.Bytes())
+func (e EventData) String() string {
+	return string(e.Bytes())
 }
 
 type Event struct {
@@ -92,13 +92,13 @@ func MakeEvent(level Level, message string, values ...interface{}) Event {
 	}
 }
 
-func (c Event) Bytes() []byte {
-	b, _ := json.Marshal(c)
+func (e Event) Bytes() []byte {
+	b, _ := json.Marshal(e)
 	return b
 }
 
-func (c Event) String() string {
-	return string(c.Bytes())
+func (e Event) String() string {
+	return string(e.Bytes())
 }
 
 func copyEventData(data ...EventData) EventData {

--- a/lib/journald/reader.go
+++ b/lib/journald/reader.go
@@ -125,6 +125,8 @@ func (r reader) getInt(k string) (v int) {
 func (r reader) getTime() (t time.Time) {
 	if u, e := r.GetRealtimeUsec(); e == nil {
 		t = time.Unix(int64(u/1000000), int64((u%1000000)*1000))
+	} else {
+		t = time.Now()
 	}
 	return
 }

--- a/lib/message.go
+++ b/lib/message.go
@@ -20,3 +20,17 @@ func (m Message) String() string {
 func (m Message) ContentLength() int {
 	return jsonLen(m.Event)
 }
+
+type MessageBatch []Message
+
+func (list MessageBatch) Swap(i int, j int) {
+	list[i], list[j] = list[j], list[i]
+}
+
+func (list MessageBatch) Less(i int, j int) bool {
+	return list[i].Event.Time.Before(list[j].Event.Time)
+}
+
+func (list MessageBatch) Len() int {
+	return len(list)
+}

--- a/lib/message_test.go
+++ b/lib/message_test.go
@@ -34,7 +34,7 @@ func TestMessageString(t *testing.T) {
 }
 
 func TestMessageEncoderDecoder(t *testing.T) {
-	batch := []Message{
+	batch := MessageBatch{
 		Message{
 			Group:  "abc",
 			Stream: "0123456789",
@@ -71,7 +71,7 @@ func TestMessageEncoderDecoder(t *testing.T) {
 	// This loop reads the messages written to the pipe and rebuilds a list
 	// of messages until EOF is reached. The orignal batch and list are then
 	// compred to ensure they are the same.
-	var list []Message
+	var list MessageBatch
 	for {
 		if msg, err := d.ReadMessage(); err != nil {
 			if err == io.EOF {
@@ -94,7 +94,7 @@ func TestMessageEncoderDecoder(t *testing.T) {
 }
 
 func TestMessageEncoderWriteMessageBatchError(t *testing.T) {
-	batch := []Message{
+	batch := MessageBatch{
 		Message{
 			Group:  "abc",
 			Stream: "0123456789",

--- a/lib/statsd/writer.go
+++ b/lib/statsd/writer.go
@@ -93,14 +93,14 @@ func (w writer) Close() error {
 }
 
 func (w writer) WriteMessage(msg ecslogs.Message) error {
-	return w.WriteMessageBatch([]ecslogs.Message{msg})
+	return w.WriteMessageBatch(ecslogs.MessageBatch{msg})
 }
 
-func (w writer) WriteMessageBatch(batch []ecslogs.Message) error {
+func (w writer) WriteMessageBatch(batch ecslogs.MessageBatch) error {
 	return sendMetrics(w.client, extractMetrics(batch))
 }
 
-func extractMetrics(batch []ecslogs.Message) map[ecslogs.Level]*metric {
+func extractMetrics(batch ecslogs.MessageBatch) map[ecslogs.Level]*metric {
 	metrics := make(map[ecslogs.Level]*metric, 10)
 
 	for _, msg := range batch {

--- a/lib/statsd/writer_test.go
+++ b/lib/statsd/writer_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestExtractMetrics(t *testing.T) {
-	batch := []ecslogs.Message{
+	batch := ecslogs.MessageBatch{
 		ecslogs.Message{
 			Event: ecslogs.Event{Level: ecslogs.INFO},
 		},

--- a/lib/stream_test.go
+++ b/lib/stream_test.go
@@ -8,15 +8,15 @@ import (
 
 func TestSplitMessageListHead(t *testing.T) {
 	tests := []struct {
-		list  []Message
+		list  MessageBatch
 		count int
 	}{
 		{
-			list:  []Message{},
+			list:  MessageBatch{},
 			count: 0,
 		},
 		{
-			list: []Message{
+			list: MessageBatch{
 				Message{Group: "A"},
 				Message{Group: "B"},
 				Message{Group: "C"},
@@ -24,7 +24,7 @@ func TestSplitMessageListHead(t *testing.T) {
 			count: 0,
 		},
 		{
-			list: []Message{
+			list: MessageBatch{
 				Message{Group: "A"},
 				Message{Group: "B"},
 				Message{Group: "C"},
@@ -32,7 +32,7 @@ func TestSplitMessageListHead(t *testing.T) {
 			count: 1,
 		},
 		{
-			list: []Message{
+			list: MessageBatch{
 				Message{Group: "A"},
 				Message{Group: "B"},
 				Message{Group: "C"},
@@ -150,11 +150,11 @@ func TestStreamBytes(t *testing.T) {
 		MaxBytes: m1.ContentLength() + m2.ContentLength(),
 	}, ts)
 
-	if !reflect.DeepEqual(list, []Message{m1, m2}) {
+	if !reflect.DeepEqual(list, MessageBatch{m1, m2}) {
 		t.Error("invalid list of messages flushed from stream:", list)
 	}
 
-	if !reflect.DeepEqual(st.messages, []Message{m3}) {
+	if !reflect.DeepEqual(st.messages, MessageBatch{m3}) {
 		t.Error("invalid list of messages left in stream:", st.messages)
 	}
 
@@ -168,7 +168,7 @@ func TestStreamBytes(t *testing.T) {
 		MaxBytes: m3.ContentLength() - 1,
 	}, ts)
 
-	if !reflect.DeepEqual(list, []Message{m3}) {
+	if !reflect.DeepEqual(list, MessageBatch{m3}) {
 		t.Error("invalid list of messages flushed from stream:", list)
 	}
 

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -160,7 +160,7 @@ func (w *writer) Close() (err error) {
 	return
 }
 
-func (w *writer) WriteMessageBatch(batch []ecslogs.Message) (err error) {
+func (w *writer) WriteMessageBatch(batch ecslogs.MessageBatch) (err error) {
 	for _, msg := range batch {
 		if err = w.write(msg); err != nil {
 			return

--- a/lib/writer.go
+++ b/lib/writer.go
@@ -10,7 +10,7 @@ type Writer interface {
 
 	WriteMessage(Message) error
 
-	WriteMessageBatch([]Message) error
+	WriteMessageBatch(MessageBatch) error
 }
 
 func NewMessageEncoder(w io.Writer) Writer {
@@ -34,7 +34,7 @@ func (e encoder) WriteMessage(msg Message) (err error) {
 	return
 }
 
-func (e encoder) WriteMessageBatch(batch []Message) (err error) {
+func (e encoder) WriteMessageBatch(batch MessageBatch) (err error) {
 	for _, msg := range batch {
 		if err = e.WriteMessage(msg); err != nil {
 			return

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -238,6 +239,16 @@ func flush(dests []destination, group *ecslogs.Group, stream *ecslogs.Stream, li
 
 		if len(batch) == 0 {
 			break
+		}
+
+		// Ensure all messages in the batch are sorted. Checking if the batch is
+		// sorted is an optimization since in most cases the batch will be sorted
+		// because we're reading events that are generated live (checking for a
+		// sorted list is O(N) vs O(N*log(N)) for sorting it).
+		// There are cases where some log entries do appear unordered and this is
+		// causing issues with CloudWatchLogs.
+		if !sort.IsSorted(batch) {
+			sort.Sort(batch)
 		}
 
 		logf("flushing %d messages to %s::%s (%s)", len(batch), group.Name(), stream.Name(), reason)

--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func flush(dests []destination, group *ecslogs.Group, stream *ecslogs.Stream, li
 		// There are cases where some log entries do appear unordered and this is
 		// causing issues with CloudWatchLogs.
 		if !sort.IsSorted(batch) {
-			sort.Sort(batch)
+			sort.Stable(batch)
 		}
 
 		logf("flushing %d messages to %s::%s (%s)", len(batch), group.Name(), stream.Name(), reason)


### PR DESCRIPTION
@segmentio/infra 

CloudWatchLogs refuses unsorted message batches, theoretically this shouldn't be an issue since we're reading a live stream of events but apparently there are cases where logs are sent out of order by some services.
With this PR we ensure that message batches are sorted before they are sent to the writers.

Here's the error that motivated this change:
```
dropping message batch of 12 messages to app-canary::ecs-app-canary-244-app-canary-xxx (cloudwatchlogs: InvalidParameterException: Log events in a single PutLogEvents request must be in chronological order.
	status code: 400, request id: xxx)
```