### PR TITLE
fix random cloudwatch failures

### DIFF
--- a/lib/cloudwatchlogs/client.go
+++ b/lib/cloudwatchlogs/client.go
@@ -1,7 +1,6 @@
 package cloudwatchlogs
 
 import (
-	"errors"
 	"strings"
 	"sync"
 
@@ -156,7 +155,3 @@ func createGroupAndStream(client *cloudwatchlogs.CloudWatchLogs, group string, s
 func joinGroupStream(group string, stream string) string {
 	return group + "::" + stream
 }
-
-var (
-	errDescribeLogStream = errors.New("getting the log stream description failed")
-)

--- a/lib/cloudwatchlogs/client.go
+++ b/lib/cloudwatchlogs/client.go
@@ -146,7 +146,6 @@ func createGroupAndStream(client *cloudwatchlogs.CloudWatchLogs, group string, s
 	}
 
 	if len(result.LogStreams) == 0 {
-		err = errDescribeLogStream
 		return
 	}
 


### PR DESCRIPTION
@segmentio/infra 

I don't know how exactly this is possible, looks like a race condition in CloudWatchLogs, the API call did not return any error but didn't return any result either... 

The work around here is to just ignore the issue, we won't have any upload token but we should be able to retrieve it later when a message batch is about to be uploaded.

Here's the error that motivated this change:
```
2016-07-06T01:58:57.192710047Z dropping message batch of 8 messages to etl-render::ecs-etl-render-3-etl-render-xxx (cloudwatchlogs: getting the log stream description failed)
```