### PR TITLE
Self logs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "vendor/github.com/segmentio/ecs-logs-go"]
 	path = vendor/github.com/segmentio/ecs-logs-go
 	url = https://github.com/segmentio/ecs-logs-go
+[submodule "vendor/github.com/apex/log"]
+	path = vendor/github.com/apex/log
+	url = https://github.com/apex/log

--- a/lib/log.go
+++ b/lib/log.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"github.com/apex/log"
+	"github.com/segmentio/ecs-logs-go"
 	"github.com/segmentio/ecs-logs-go/apex"
 )
 
@@ -40,6 +41,14 @@ func (h *LogHandler) HandleLog(entry *log.Entry) (err error) {
 
 	if len(msg.Event.Info.Host) == 0 {
 		msg.Event.Info.Host = h.Hostname
+	}
+
+	if len(msg.Event.Info.Source) == 0 {
+		if pc, ok := ecslogs.GuessCaller(0, 10, "github.com/segmentio/ecs-logs/lib", "github.com/apex/log"); ok {
+			if info, ok := ecslogs.GetFuncInfo(pc); ok {
+				msg.Event.Info.Source = info.String()
+			}
+		}
 	}
 
 	h.Queue.Push(msg)

--- a/lib/log.go
+++ b/lib/log.go
@@ -1,0 +1,48 @@
+package lib
+
+import (
+	"github.com/apex/log"
+	"github.com/segmentio/ecs-logs-go/apex"
+)
+
+type LogLevel log.Level
+
+func (lvl *LogLevel) Set(s string) error {
+	if l, e := log.ParseLevel(s); e != nil {
+		return e
+	} else {
+		*lvl = LogLevel(l)
+		return nil
+	}
+}
+
+func (lvl LogLevel) Get() interface{} {
+	return lvl
+}
+
+func (lvl LogLevel) String() string {
+	return log.Level(lvl).String()
+}
+
+type LogHandler struct {
+	Group    string
+	Stream   string
+	Hostname string
+	Queue    *MessageQueue
+}
+
+func (h *LogHandler) HandleLog(entry *log.Entry) (err error) {
+	msg := Message{
+		Group:  h.Group,
+		Stream: h.Stream,
+		Event:  apex_ecslogs.MakeEvent(entry),
+	}
+
+	if len(msg.Event.Info.Host) == 0 {
+		msg.Event.Info.Host = h.Hostname
+	}
+
+	h.Queue.Push(msg)
+	h.Queue.Notify()
+	return
+}

--- a/main.go
+++ b/main.go
@@ -248,7 +248,7 @@ func read(r reader, c chan<- lib.Message, counter *int32, hostname string) {
 	}
 }
 
-func write(dest destination, group string, stream string, batch []lib.Message, join *sync.WaitGroup) {
+func write(dest destination, group string, stream string, batch lib.MessageBatch, join *sync.WaitGroup) {
 	defer join.Done()
 
 	var writer lib.Writer
@@ -335,7 +335,7 @@ func removeExpired(dests []destination, store *lib.Store, cacheTimeout time.Dura
 	}
 }
 
-func logDropBatch(dest string, group string, stream string, err error, batch []lib.Message) {
+func logDropBatch(dest string, group string, stream string, err error, batch lib.MessageBatch) {
 	log.WithFields(log.Fields{
 		"group":       group,
 		"stream":      stream,

--- a/main.go
+++ b/main.go
@@ -69,6 +69,10 @@ func main() {
 	var readers []reader
 	var dests []destination
 
+	if len(hostname) == 0 {
+		log.Fatal("no hostname configured")
+	}
+
 	if sources = getSources(strings.Split(src, ",")); len(sources) == 0 {
 		log.Fatal("no or invalid log sources")
 	}


### PR DESCRIPTION
@segmentio/infra 

This PR adds the ability for ecs-logs to forward its own logs into its writers pipeline. This has multiple advantages like having ecs-logs available in a centralized place, with the datadog integration this also automatically provides insights into warnings/errors generated by ecs-logs.

The implementation uses the `apex/log` package and the `multi.Handler` to fan out the logs to both stdout and the ecs-logs writers, here's an example of what is logged to stdout:
```
   • waiting for all write operations to complete
   • flushing message batch    count=1 group=abc reason=forced flushing stream=0123456789
   • flushing message batch    count=2 group=ecs-logs reason=forced flushing stream=MacBook-Pro.local
```