### PR TITLE
logdna: adding to main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 
 	_ "github.com/segmentio/ecs-logs/lib/cloudwatchlogs"
 	_ "github.com/segmentio/ecs-logs/lib/datadog"
+	_ "github.com/segmentio/ecs-logs/lib/logdna"
 	_ "github.com/segmentio/ecs-logs/lib/loggly"
 	_ "github.com/segmentio/ecs-logs/lib/statsd"
 	_ "github.com/segmentio/ecs-logs/lib/syslog"


### PR DESCRIPTION
This commit adds logdna so that we can test them out as a sink