### PR TITLE
Update LogDNA writer to follow syslog RFC 5424

### DIFF
--- a/lib/logdna/writer.go
+++ b/lib/logdna/writer.go
@@ -33,7 +33,7 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 	}
 
 	if timeFormat = os.Getenv("LOGDNA_TIME_FORMAT"); len(timeFormat) == 0 {
-		timeFormat = "2016-02-10T09:28:01.982Z08:00"
+		timeFormat = "2016-02-10T09:28:01.982-08:00"
 	}
 
 	return syslog.DialWriter(syslog.WriterConfig{


### PR DESCRIPTION
We received a support ticket this morning about an issue with structured data being picked up by our syslog parser. Realized that the previous PR was made a few days before we officially supported structured data (e.g. tags), so writer.go has been updated to support syslog RFC 5424. This PR also updates the timestamp to follow the RFC 3339 timestamp format.