### PR TITLE
Add support for socks5 proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,8 @@ Here's an example:
 *Note that it requires your service to output JSON formatted logs with a
 structure that ecs-logs recognize.*
 
+### Proxy
+
+To send your logs through a proxy, you can set the `HTTP_PROXY` or `SOCKS_PROXY` environment variable.
+
+`SOCKS_PROXY` should follow the format `host:port`. If incorrect, the variable will be ignored.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ structure that ecs-logs recognize.*
 
 ### Proxy
 
-To send your logs through a proxy, you can set the `HTTP_PROXY` or `SOCKS_PROXY` environment variable.
+To send your logs through a proxy, you can set the `HTTP_PROXY`, `HTTPS_PROXY` or `SOCKS_PROXY` environment variable.
+
+`NO_PROXY` can also be set to filter networks where the proxy should not be used.
 
 `SOCKS_PROXY` should follow the format `host:port`. If incorrect, the variable will be ignored.

--- a/lib/logdna/writer.go
+++ b/lib/logdna/writer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/segmentio/ecs-logs/lib"
 	"github.com/segmentio/ecs-logs/lib/syslog"
 )
@@ -43,6 +44,9 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 
 	socksProxy = os.Getenv("SOCKS_PROXY")
 	if _, _, err = net.SplitHostPort(socksProxy); err != nil {
+		log.WithFields(log.Fields{
+			"SOCKS_PROXY": socksProxy,
+		}).Warn("bad format, proxy setting will be ignored")
 		socksProxy = ""
 	}
 

--- a/lib/logdna/writer.go
+++ b/lib/logdna/writer.go
@@ -3,6 +3,7 @@ package logdna
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -19,6 +20,7 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 	var tags string
 	var template string
 	var timeFormat string
+	var socksProxy string
 
 	if endpoint, err = getEndpoint(); err != nil {
 		return
@@ -39,6 +41,11 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 		timeFormat = "2016-02-10T09:28:01.982-08:00"
 	}
 
+	socksProxy = os.Getenv("SOCKS_PROXY")
+	if _, _, err = net.SplitHostPort(socksProxy); err != nil {
+		socksProxy = ""
+	}
+
 	return syslog.DialWriter(syslog.WriterConfig{
 		Network:    protocol,
 		Address:    address,
@@ -48,6 +55,7 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 		TLS: &tls.Config{
 			InsecureSkipVerify: true,
 		},
+		SocksProxy: socksProxy,
 	})
 }
 

--- a/lib/loggly/writer.go
+++ b/lib/loggly/writer.go
@@ -3,6 +3,7 @@ package loggly
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -20,6 +21,7 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 	var tags string
 	var template string
 	var timeFormat string
+	var socksProxy string
 
 	if endpoint, err = getEndpoint(); err != nil {
 		return
@@ -37,6 +39,11 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 		timeFormat = "2006-01-02T15:04:05.999Z07:00"
 	}
 
+	socksProxy = os.Getenv("SOCKS_PROXY")
+	if _, _, err = net.SplitHostPort(socksProxy); err != nil {
+		socksProxy = ""
+	}
+
 	return syslog.DialWriter(syslog.WriterConfig{
 		Network:    protocol,
 		Address:    address,
@@ -46,6 +53,7 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 		TLS: &tls.Config{
 			InsecureSkipVerify: true,
 		},
+		SocksProxy: socksProxy,
 	})
 }
 

--- a/lib/loggly/writer.go
+++ b/lib/loggly/writer.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/apex/log"
 	"github.com/segmentio/ecs-logs/lib"
 	"github.com/segmentio/ecs-logs/lib/syslog"
 )
@@ -41,6 +42,9 @@ func NewWriter(group string, stream string) (w lib.Writer, err error) {
 
 	socksProxy = os.Getenv("SOCKS_PROXY")
 	if _, _, err = net.SplitHostPort(socksProxy); err != nil {
+		log.WithFields(log.Fields{
+			"SOCKS_PROXY": socksProxy,
+		}).Warn("bad format, proxy setting will be ignored")
 		socksProxy = ""
 	}
 

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -14,6 +14,8 @@ import (
 	"text/template"
 	"time"
 
+	"golang.org/x/net/proxy"
+
 	"github.com/segmentio/ecs-logs/lib"
 )
 
@@ -28,6 +30,7 @@ type WriterConfig struct {
 	TimeFormat string
 	Tag        string
 	TLS        *tls.Config
+	SocksProxy string
 }
 
 func NewWriter(group string, stream string) (w lib.Writer, err error) {
@@ -83,7 +86,7 @@ func DialWriter(config WriterConfig) (w lib.Writer, err error) {
 connect:
 	for _, n := range netopts {
 		for _, a := range addropts {
-			if backend, err = dialWriter(n, a, config.TLS); err == nil {
+			if backend, err = dialWriter(n, a, config.TLS, config.SocksProxy); err == nil {
 				break connect
 			}
 		}
@@ -241,16 +244,25 @@ func (c bufferedConn) Close() error                { return c.conn.Close() }
 func (c bufferedConn) Flush() error                { return c.buf.Flush() }
 func (c bufferedConn) Write(b []byte) (int, error) { return c.buf.Write(b) }
 
-func dialWriter(network string, address string, config *tls.Config) (w io.Writer, err error) {
+func dialWriter(network string, address string, config *tls.Config, socksProxy string) (w io.Writer, err error) {
 	var conn net.Conn
 	var dial func(string, string) (net.Conn, error)
+	var socksDialer *SocksDialer
 
 	if network == "tls" {
-		network, dial = "tcp", func(network string, address string) (net.Conn, error) {
+		network, dial = "tcp", func(network, address string) (net.Conn, error) {
 			return tls.Dial(network, address, config)
 		}
 	} else {
 		dial = net.Dial
+	}
+
+	if socksProxy != "" {
+		socksDialer = &SocksDialer{tlsConfig: config}
+		if err = socksDialer.connect(network, socksProxy); err != nil {
+			return
+		}
+		dial = socksDialer.dial
 	}
 
 	for attempt := 1; true; attempt++ {
@@ -278,5 +290,33 @@ func dialWriter(network string, address string, config *tls.Config) (w io.Writer
 		}
 	}
 
+	return
+}
+
+type SocksDialer struct {
+	dialer    proxy.Dialer
+	tlsConfig *tls.Config
+}
+
+func (d *SocksDialer) connect(network, proxyAddr string) (err error) {
+	d.dialer, err = proxy.SOCKS5(network, proxyAddr, nil, proxy.Direct)
+	return
+}
+
+func (d *SocksDialer) dial(network, address string) (conn net.Conn, err error) {
+	var rawConn net.Conn
+	if d.tlsConfig == nil {
+		conn, err = d.dialer.Dial(network, address)
+	} else {
+		rawConn, err = d.dialer.Dial(network, address)
+		if err != nil {
+			return
+		}
+
+		tlsConn := tls.Client(rawConn, d.tlsConfig)
+		if err = tlsConn.Handshake(); err == nil {
+			conn = tlsConn
+		}
+	}
 	return
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -199,6 +199,12 @@
 			"path": "github.com/visionmedia/go-debug",
 			"revision": "ff4a55a20a86994118644bbddc6a216da193cc13",
 			"revisionTime": "2014-10-22T19:30:16Z"
+		},
+		{
+			"checksumSHA1": "fjMK2G5arnjllpoeBYeyf9Y2Iok=",
+			"path": "golang.org/x/net/proxy",
+			"revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
+			"revisionTime": "2017-03-29T01:43:45Z"
 		}
 	],
 	"rootPath": "github.com/segmentio/ecs-logs"


### PR DESCRIPTION
This PR intends to add the support for socks5 proxy into the syslog writer. Proxy should be set by using the variable `SOCKS_PROXY`.