### PR TITLE
[lib/journald] Use task ARN for stream name if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ The journald source expects to find the *CONTAINER_TAG* and *CONTAINER_NAME*
 metadata on log events, which it uses to set the group and stream to which the
 log event will be sent.
 
+You can override the stream name by setting the `JOURNALD_STREAM_NAME` environment
+variable with a different journald metadata field to read the stream name from.
+
 The log message can be either plain text or JSON formatted. When ecs-logs fails
 to parse a JSON message, either because the content is not JSON or because the
 format is not something it understands, it will generate a log event where the


### PR DESCRIPTION
This pulls the container task ARN out of the `CONTAINER_TASK` journald meta data if it exists.  This is so that we can name log streams as task UUIDs for easier retrieval.

I also added a `sanitize` function for stream names that makes sure the log stream name is valid per Cloudwatch logs rules.