### PR TITLE
syslog: Cache connections

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: segment/golang:latest
+      - image: segment/golang:1.9
     working_directory: /go/src/github.com/segmentio/ecs-logs
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # We need a go compiler that's based on an image with libsystemd-dev installed,
 # segment/golang give us just that.
-FROM segment/golang:latest
+FROM segment/golang:1.9
 
 # Copy the ecs-logs sources so they can be built within the container.
 COPY . /go/src/github.com/segmentio/ecs-logs


### PR DESCRIPTION
ecs-logs was opening a new syslog TCP connection for every message
batch.  This had many undesirable downstream resource utilization
impacts (among them, port exhaustion on our SOCKS proxies) and is
arguably unnecessary anyway.   Also, opening a new connection
each time causes the TCP session (either from the SOCKS proxy, or
directly from the client) not to be able to take advantage of
window scaling.

With this change, we now keep each syslog connection in a cache (keyed
by destination) and reuse it if we can.

NOTE: To keep the change simple, I'm not going so far as to add connection
pooling right now.  If we can't get adequate throughput with a single TCP
connection (which should increase as window scaling kicks in), then let's revisit.