### PR TITLE
Pool syslog writers - F8N-105

### DIFF
--- a/lib/syslog/pool/pool.go
+++ b/lib/syslog/pool/pool.go
@@ -8,7 +8,7 @@ import (
 // the total number of live connections is limited to the size
 // parameter passed to NewLimited. In order to make this guarantee,
 // we assume that all new connections are introduced by calls to the
-// Get method, and return to the pool by the Put method (whether
+// Get method, and returned to the pool by the Put method (whether
 // or not the connection is dead)
 type LimitedConnPool struct {
 	conns  chan io.WriteCloser // Available connections in the pool

--- a/lib/syslog/pool/pool.go
+++ b/lib/syslog/pool/pool.go
@@ -1,0 +1,79 @@
+package pool
+
+import (
+	"io"
+)
+
+// A LimitedConnPool is a connection pool, with the property that
+// the total number of live connections is limited to the size
+// parameter passed to New.
+type LimitedConnPool struct {
+	conns  chan io.WriteCloser // Available connections in the pool
+	live   chan struct{}       // Keep a count of living connections (in our hands, or the client)
+	signal chan struct{}       // Used to wake up the connection producer
+	err    chan error          // Send dial errors back to the client
+}
+
+// New returns a new LimitedConnPool.
+func New(dial func() (io.WriteCloser, error), size int) (*LimitedConnPool, error) {
+	// Tentative first try - if this doesn't work, we assume it never will
+	// and fail to initialize.
+	w, err := dial()
+	if err != nil {
+		return nil, err
+	}
+
+	p := LimitedConnPool{
+		conns:  make(chan io.WriteCloser, size),
+		live:   make(chan struct{}, size),
+		signal: make(chan struct{}),
+		err:    make(chan error),
+	}
+
+	p.conns <- w
+	p.live <- struct{}{}
+
+	// keep p.conns populated
+	go func() {
+		for range p.signal {
+			for len(p.live) < size {
+				w, err := dial()
+				if err != nil {
+					p.err <- err
+					continue
+				}
+				p.conns <- w
+				p.live <- struct{}{}
+			}
+		}
+	}()
+
+	// kick off the producer
+	p.signal <- struct{}{}
+
+	return &p, nil
+}
+
+// Put returns a connection to the pool.
+func (p *LimitedConnPool) Put(w io.WriteCloser, dead bool) error {
+	if dead {
+		<-p.live               // decrement the live count
+		p.signal <- struct{}{} // signal the connection dialer
+		return w.Close()
+	}
+	p.conns <- w
+	return nil
+}
+
+// Get gets a connection from the pool.
+func (p *LimitedConnPool) Get() io.WriteCloser {
+	return <-p.conns
+}
+
+// Errors returns a channel of errors encountered when dialing new
+// connections. This channel must be consumed, or new connections
+// will not be dialed. To limit the retry rate, limit the consumption rate
+// of the error channel.
+func (p *LimitedConnPool) Errors() <-chan error {
+	return p.err
+}

--- a/lib/syslog/pool/pool.go
+++ b/lib/syslog/pool/pool.go
@@ -20,7 +20,10 @@ type LimitedConnPool struct {
 // NewLimited returns a new LimitedConnPool with the given size limit and dial function.
 func NewLimited(size int, dial func() (io.WriteCloser, error)) (*LimitedConnPool, error) {
 	// Tentative first try - if this doesn't work, we assume it never will
-	// and fail to initialize.
+	// and fail to initialize. This is admittedly not great, but we rely on
+	// unreachable addresses failing immediately in our syslog package, which,
+	// if no address is specified, attempts a number of fallback addresses
+	// until one succeeds.
 	w, err := dial()
 	if err != nil {
 		return nil, err

--- a/lib/syslog/pool/pool_test.go
+++ b/lib/syslog/pool/pool_test.go
@@ -1,36 +1,44 @@
 package pool
 
 import (
-	"errors"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"os"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestPool(t *testing.T) {
-	const size = 100
+	const poolSize = 100
 
-	// dialer which randomly fails 10% of the time
-	dial := func() (io.WriteCloser, error) {
-		if n := rand.Intn(10); n < 9 {
-			return os.OpenFile(os.DevNull, os.O_RDWR, 0)
-		}
-		return nil, errors.New("failed to dial")
-	}
-
-	p, err := NewLimited(size, dial)
+	dir, err := ioutil.TempDir("", "pool_test")
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
+
+	var newConnections int
+	dial := func() (io.WriteCloser, error) {
+		newConnections++
+		return ioutil.TempFile(dir, "")
+	}
+
+	p, err := NewLimited(poolSize, dial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
 
 	// consume errors from the pool
 	var failures uint64
 	go func() {
-		for range p.Errors() {
+		for err := range p.Errors() {
 			atomic.AddUint64(&failures, 1)
+			fmt.Fprintln(os.Stderr, err.Error())
 		}
 	}()
 
@@ -42,10 +50,18 @@ func TestPool(t *testing.T) {
 		}
 	}()
 
-	// start 2 * (pool size) writer goroutines
-	for i := 0; i < 2*size; i++ {
+	var wg sync.WaitGroup
+
+	// start 2*poolSize writer goroutines
+	for i := 0; i < 2*poolSize; i++ {
+		start := time.Now()
+		stop := 10 * time.Second
+		if testing.Short() {
+			stop = 2 * time.Second
+		}
+		wg.Add(1)
 		go func() {
-			for {
+			for time.Since(start) < stop {
 				// wait a bit before getting a conn from the pool
 				time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
 				w := p.Get()
@@ -53,29 +69,23 @@ func TestPool(t *testing.T) {
 				// random number of writes, with random waits in between
 				for j := 0; j < rand.Intn(10); j++ {
 					time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
-					if _, err := w.Write([]byte("test")); err != nil {
+					if _, err := w.Write([]byte("test\n")); err != nil {
 						t.Error(err)
 					}
 				}
 
-				// randomly decide if the connection should be considered dead
-				dead := false
-				if rand.Intn(10) == 9 {
-					dead = true
-				}
-
 				// return the conn to the pool
-				if err := p.Put(w, dead); err != nil {
+				if err := w.Close(); err != nil {
 					t.Error(err)
 				}
 			}
+			wg.Done()
 		}()
 	}
 
-	// let the test run for a bit
-	if testing.Short() {
-		time.Sleep(2 * time.Second)
-	} else {
-		time.Sleep(10 * time.Second)
+	wg.Wait()
+
+	if newConnections != poolSize {
+		t.Errorf("dialed %d connections, want %d", newConnections, poolSize)
 	}
 }

--- a/lib/syslog/pool/pool_test.go
+++ b/lib/syslog/pool/pool_test.go
@@ -1,0 +1,81 @@
+package pool
+
+import (
+	"errors"
+	"io"
+	"math/rand"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestPool(t *testing.T) {
+	const size = 100
+
+	// dialer which randomly fails 10% of the time
+	dial := func() (io.WriteCloser, error) {
+		if n := rand.Intn(10); n < 9 {
+			return os.OpenFile(os.DevNull, os.O_RDWR, 0)
+		}
+		return nil, errors.New("failed to dial")
+	}
+
+	p, err := New(dial, size)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// consume errors from the pool
+	var failures uint64
+	go func() {
+		for range p.Errors() {
+			atomic.AddUint64(&failures, 1)
+		}
+	}()
+
+	// report pool stats once per second
+	go func() {
+		start := time.Now()
+		for range time.Tick(1 * time.Second) {
+			t.Logf("T+%02.2vs: live=%d pool=%d failures=%d\n", time.Since(start).Seconds(), len(p.live), len(p.conns), atomic.LoadUint64(&failures))
+		}
+	}()
+
+	// start 2 * (pool size) writer goroutines
+	for i := 0; i < 2*size; i++ {
+		go func() {
+			for {
+				// wait a bit before getting a conn from the pool
+				time.Sleep(time.Duration(rand.Intn(100)) * time.Millisecond)
+				w := p.Get()
+
+				// random number of writes, with random waits in between
+				for j := 0; j < rand.Intn(10); j++ {
+					time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+					if _, err := w.Write([]byte("test")); err != nil {
+						t.Error(err)
+					}
+				}
+
+				// randomly decide if the connection should be considered dead
+				dead := false
+				if rand.Intn(10) == 9 {
+					dead = true
+				}
+
+				// return the conn to the pool
+				if err := p.Put(w, dead); err != nil {
+					t.Error(err)
+				}
+			}
+		}()
+	}
+
+	// let the test run for a bit
+	if testing.Short() {
+		time.Sleep(2 * time.Second)
+	} else {
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/lib/syslog/pool/pool_test.go
+++ b/lib/syslog/pool/pool_test.go
@@ -21,7 +21,7 @@ func TestPool(t *testing.T) {
 		return nil, errors.New("failed to dial")
 	}
 
-	p, err := New(dial, size)
+	p, err := NewLimited(size, dial)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -194,11 +194,12 @@ func (w *writer) Close() (err error) {
 		// If the pool is full, discard this writer.
 		select {
 		case writerPool <- w:
+			return nil
 		default:
-			return w.backend.Close()
 		}
 	}
-	return nil
+
+	return w.backend.Close()
 }
 
 func (w *writer) WriteMessageBatch(batch lib.MessageBatch) error {

--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -22,12 +22,16 @@ import (
 
 const DefaultTemplate = "<{{.PRIVAL}}>{{.TIMESTAMP}} {{.GROUP}}[{{.STREAM}}]: {{.MSG}}"
 
-// Global writer pool - channel style. Each writer is configured
-// using the same environment variables, so any connection is usable
-// by any caller. Writers graduate to the pool if Close() is called
-// and no errors have occured while writing to the writer.
+// Global writer pool - channel style.
+// When NewWriter is called, a writer is taken from the pool if available.
+// Otherwise a new writer is created. Since each writer is configured
+// using the same environment variables, any writer can be used by any caller.
+// When writer.Close() is called, the writer is put back into the pool if
+// no errors have occured, or closed and discarded otherwise.
 var (
-	writerPool     = make(chan *writer, 100)
+	writerPool = make(chan *writer, 100)
+
+	// Useful for testing
 	enablePooling  = false
 	newConnections uint64
 )

--- a/lib/syslog/writer_test.go
+++ b/lib/syslog/writer_test.go
@@ -3,7 +3,6 @@ package syslog
 import (
 	"fmt"
 	"math/rand"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -13,31 +12,7 @@ import (
 
 const testGoroutines = 50
 
-func TestWriterPool(t *testing.T) {
-	enablePooling = true
-
-	// Verify that a sane number of writers are going into the pool.
-	go func() {
-		start := time.Now()
-		for range time.Tick(1 * time.Second) {
-			if length := len(writerPool); length > testGoroutines {
-				t.Errorf("got len(writerPool)=%d, want <= %d", length, testGoroutines)
-			} else {
-				t.Logf("T+%02.2vs: %d writers in the pool\n", time.Since(start).Seconds(), length)
-			}
-
-		}
-	}()
-
-	testWriter(t)
-}
-
-func TestWriterNoPool(t *testing.T) {
-	enablePooling = false
-	testWriter(t)
-}
-
-func testWriter(t *testing.T) {
+func TestWriter(t *testing.T) {
 	// Start a bunch of workers who open and close writers like crazy.
 	errc := make(chan error, testGoroutines)
 	start := time.Now()
@@ -76,5 +51,5 @@ func testWriter(t *testing.T) {
 		}
 	}
 
-	t.Logf("total new connections made: %d", atomic.LoadUint64(&newConnections))
+	//t.Logf("total new connections made: %d", atomic.LoadUint64(&newConnections))
 }

--- a/lib/syslog/writer_test.go
+++ b/lib/syslog/writer_test.go
@@ -1,0 +1,79 @@
+package syslog
+
+import (
+	"fmt"
+	"math/rand"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ecslogs "github.com/segmentio/ecs-logs-go"
+	"github.com/segmentio/ecs-logs/lib"
+)
+
+const testGoroutines = 50
+
+func TestWriterPool(t *testing.T) {
+	enablePooling = true
+
+	// Verify that a sane number of writers are going into the pool.
+	go func() {
+		for range time.Tick(1 * time.Second) {
+			if length := len(writerPool); length > testGoroutines {
+				t.Errorf("got len(writerPool)=%d, want <= %d", length, testGoroutines)
+			} else {
+				t.Logf("%d writers in the pool\n", length)
+			}
+
+		}
+	}()
+
+	testWriter(t)
+}
+
+func TestWriterNoPool(t *testing.T) {
+	enablePooling = false
+	testWriter(t)
+}
+
+func testWriter(t *testing.T) {
+	// Start a bunch of workers who open and close writers like crazy.
+	errc := make(chan error, testGoroutines)
+	start := time.Now()
+	for i := 0; i < testGoroutines; i++ {
+		go func(i int) {
+			for {
+				d := time.Duration(rand.Intn(100)) * time.Millisecond
+				time.Sleep(d)
+				w, err := NewWriter("foo", "bar")
+				if err != nil {
+					errc <- err
+				}
+				err = w.WriteMessage(lib.Message{
+					Group:  "foo",
+					Stream: "bar",
+					Event:  ecslogs.MakeEvent(ecslogs.INFO, fmt.Sprintf("slept %v", d)),
+				})
+				if err != nil {
+					errc <- err
+				}
+				if err := w.Close(); err != nil {
+					errc <- err
+				}
+
+				if time.Since(start) >= 10*time.Second {
+					errc <- nil
+					return
+				}
+			}
+		}(i)
+	}
+
+	for i := 0; i < testGoroutines; i++ {
+		if err := <-errc; err != nil {
+			t.Error(err)
+		}
+	}
+
+	t.Logf("total new connections made: %d", atomic.LoadUint64(&newConnections))
+}

--- a/lib/syslog/writer_test.go
+++ b/lib/syslog/writer_test.go
@@ -18,11 +18,12 @@ func TestWriterPool(t *testing.T) {
 
 	// Verify that a sane number of writers are going into the pool.
 	go func() {
+		start := time.Now()
 		for range time.Tick(1 * time.Second) {
 			if length := len(writerPool); length > testGoroutines {
 				t.Errorf("got len(writerPool)=%d, want <= %d", length, testGoroutines)
 			} else {
-				t.Logf("%d writers in the pool\n", length)
+				t.Logf("T+%02.2vs: %d writers in the pool\n", time.Since(start).Seconds(), length)
 			}
 
 		}

--- a/lib/syslog/writer_test.go
+++ b/lib/syslog/writer_test.go
@@ -43,7 +43,7 @@ func testWriter(t *testing.T) {
 	for i := 0; i < testGoroutines; i++ {
 		go func(i int) {
 			for {
-				d := time.Duration(rand.Intn(100)) * time.Millisecond
+				d := time.Duration(rand.Intn(10)) * time.Millisecond
 				time.Sleep(d)
 				w, err := NewWriter("foo", "bar")
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -295,7 +295,7 @@ func read(r reader, c chan<- lib.Message, counter *int32, hostname string) {
 	}
 }
 
-func write(dest destination, group string, stream string, batch lib.MessageBatch, join *sync.WaitGroup) {
+func write(dest destination, group, stream string, batch lib.MessageBatch, join *sync.WaitGroup) {
 	defer join.Done()
 
 	var writer lib.Writer

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -165,6 +165,12 @@
 			"revisionTime": "2016-02-02T18:50:14Z"
 		},
 		{
+			"checksumSHA1": "qekNouYjoxRxaEZeD6GtySY1wlM=",
+			"path": "github.com/jpillora/backoff",
+			"revision": "8eab2debe79d12b7bd3d10653910df25fa9552ba",
+			"revisionTime": "2017-09-18T00:21:02Z"
+		},
+		{
 			"checksumSHA1": "sLM5tRtL85eSdaxblyygnEB9kUI=",
 			"path": "github.com/segmentio/ecs-logs-go",
 			"revision": "2f43d53e6e42c8b779b03e4fb7c1838a9c57c0b6",


### PR DESCRIPTION
This change doesn't provide any hard guarantees about how many writers (= tcp connections) can exist at once, but it does (in testing) greatly decrease the number of new connections that are opened, and total number of active connections.

From what I understand reading main.go, writers are created and closed for each batch of messages (to be confirmed - I want to talk to @achille-roussel  about this), so this should greatly reduce the number of TCP handshakes happening. Even if this doesn't solve the issue, and we still want a strict limit on open connections, I think this is a fairly simple change that should improve the situation and make it easier to add the limit if necessary.

This test output shows the difference between the old and new implementations, when clients create and close writers very often (note that I actually hit my open file limit and see intermittent failures when pooling is disabled) :
```
~/dev/src/github.com/segmentio/ecs-logs/lib/syslog $ go test -v -race 
=== RUN   TestWriterPool
--- PASS: TestWriterPool (10.01s)
	writer_test.go:26: T+01s: 12 writers in the pool
	writer_test.go:26: T+02s: 29 writers in the pool
	writer_test.go:26: T+03s: 30 writers in the pool
	writer_test.go:26: T+04s: 31 writers in the pool
	writer_test.go:26: T+05s: 31 writers in the pool
	writer_test.go:26: T+06s: 30 writers in the pool
	writer_test.go:26: T+07s: 30 writers in the pool
	writer_test.go:26: T+08s: 30 writers in the pool
	writer_test.go:26: T+09s: 28 writers in the pool
	writer_test.go:26: T+10s: 38 writers in the pool
	writer_test.go:79: total new connections made: 40
=== RUN   TestWriterNoPool
--- FAIL: TestWriterNoPool (32.12s)
	writer_test.go:75: write tcp [::1]:56010->[::1]:5140: write: broken pipe
	writer_test.go:75: write tcp [::1]:56013->[::1]:5140: write: broken pipe
	writer_test.go:75: write tcp [::1]:56008->[::1]:5140: write: broken pipe
	writer_test.go:79: total new connections made: 17367
FAIL
exit status 1
FAIL	github.com/segmentio/ecs-logs/lib/syslog	42.155s

```
