### PR TITLE
Add pprof handler and benchmarks

### DIFF
--- a/lib/syslog/writer_test.go
+++ b/lib/syslog/writer_test.go
@@ -58,3 +58,45 @@ func TestWriter(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkNewWriter(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		w, err := NewWriter("foo", "bar")
+		if err != nil {
+			b.Fatal(err)
+		}
+		for j := 0; j < 10; j++ {
+			err := w.WriteMessage(lib.Message{
+				Group:  "foo",
+				Stream: "bar",
+				Event:  ecslogs.MakeEvent(ecslogs.INFO, "test"),
+			})
+			if err != nil {
+				b.Error(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkWrite(b *testing.B) {
+	w, err := NewWriter("foo", "bar")
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		err := w.WriteMessage(lib.Message{
+			Group:  "foo",
+			Stream: "bar",
+			Event:  ecslogs.MakeEvent(ecslogs.INFO, "test"),
+		})
+		if err != nil {
+			b.Error(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		b.Fatal(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 	// serve profiles if address is configured
 	if profileAddr != "" {
 		go func() {
-			if err := http.ListenAndServe("localhost:8080", nil); err != nil {
+			if err := http.ListenAndServe(profileAddr, nil); err != nil {
 				log.Errorf("pprof: %v", err)
 			}
 		}()

--- a/main.go
+++ b/main.go
@@ -13,6 +13,9 @@ import (
 	"syscall"
 	"time"
 
+	"net/http"
+	_ "net/http/pprof"
+
 	"github.com/apex/log"
 	"github.com/apex/log/handlers/cli"
 	"github.com/apex/log/handlers/multi"
@@ -52,6 +55,7 @@ func main() {
 	var maxCount int
 	var flushTimeout time.Duration
 	var cacheTimeout time.Duration
+	var profileAddr string
 
 	hostname, _ = os.Hostname()
 
@@ -63,6 +67,7 @@ func main() {
 	flag.IntVar(&maxCount, "max-batch-size", 10000, "The maximum number of messages in a batch")
 	flag.DurationVar(&flushTimeout, "flush-timeout", 5*time.Second, "How often messages will be flushed")
 	flag.DurationVar(&cacheTimeout, "cache-timeout", 5*time.Minute, "How to wait before clearing unused internal cache")
+	flag.StringVar(&profileAddr, "pprof-addr", "localhost:8080", "Address to serve profile information")
 	flag.Parse()
 
 	logger := &lib.LogHandler{
@@ -73,6 +78,15 @@ func main() {
 	}
 	log.SetLevel(log.Level(level))
 	log.SetHandler(multi.New(cli.New(os.Stderr), logger))
+
+	// serve profiles if address is configured
+	if profileAddr != "" {
+		go func() {
+			if err := http.ListenAndServe("localhost:8080", nil); err != nil {
+				log.Errorf("pprof: %v", err)
+			}
+		}()
+	}
 
 	var store = lib.NewStore()
 	var sources []source

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func main() {
 	flag.IntVar(&maxCount, "max-batch-size", 10000, "The maximum number of messages in a batch")
 	flag.DurationVar(&flushTimeout, "flush-timeout", 5*time.Second, "How often messages will be flushed")
 	flag.DurationVar(&cacheTimeout, "cache-timeout", 5*time.Minute, "How to wait before clearing unused internal cache")
-	flag.StringVar(&profileAddr, "pprof-addr", "localhost:8080", "Address to serve profile information")
+	flag.StringVar(&profileAddr, "pprof-addr", "", "Address to serve profile information")
 	flag.Parse()
 
 	logger := &lib.LogHandler{


### PR DESCRIPTION
Add the net/http/pprof handler, with a configurable address.

It's proving difficult to simulate production workloads for ecs-logs. This will help collect heap allocation info, which saw a sharp increase with the previous connection pool change in lib/syslog.

I also threw in some benchmarks that I have been using to benchmark allocations.