### PR TITLE
Don't create new pools for each connection

### DIFF
--- a/lib/syslog/writer.go
+++ b/lib/syslog/writer.go
@@ -53,7 +53,7 @@ type dialOpts struct {
 // so we are assuming that all otherwise identical dialOpts
 // have the same TLS config.
 func (o *dialOpts) key() string {
-	return o.network + o.address + o.socksProxy
+	return fmt.Sprintf("%s:%s:%s", o.network, o.address, o.socksProxy)
 }
 
 func init() {

--- a/lib/syslog/writer_test.go
+++ b/lib/syslog/writer_test.go
@@ -69,12 +69,9 @@ func TestGetPool(t *testing.T) {
 		t.Fatal("SYSLOG_URL must be set")
 	}
 
-	network := u.Scheme
-	address := u.Host
-
 	opts := dialOpts{
-		network: network,
-		address: address,
+		network: u.Scheme,
+		address: u.Host,
 		tls: &tls.Config{
 			InsecureSkipVerify: true,
 		},
@@ -86,10 +83,10 @@ func TestGetPool(t *testing.T) {
 	}
 	defer pool1.Close()
 
-	// make a new dialOpts identical to the old one
+	// Create a new dialOpts identical to the old one
 	opts = dialOpts{
-		network: network,
-		address: address,
+		network: u.Scheme,
+		address: u.Host,
 		tls: &tls.Config{
 			InsecureSkipVerify: true,
 		},


### PR DESCRIPTION
Each call to `logdna.NewWriter` was creating a new `syslog.dialOpts` which should have been identical to the others, but actually was not because `dialOpts.tls` was pointing to a different `tls.Config` object in each case. This resulted in a new pool being created for each writer.

Fix this by indexing `connPools` with a string representation of `dialOpts`.

Unfortunately, it does not seem feasible to capture the `tls.Config` in this new key, but in practice this seems unlikely to be an issue.

Also add a test which is fixed by this change.