### PR TITLE
Add MessageBatch.Bytes() convenience method

### DIFF
--- a/lib/message.go
+++ b/lib/message.go
@@ -1,6 +1,7 @@
 package lib
 
 import (
+	"bytes"
 	"encoding/json"
 	"sync"
 
@@ -40,6 +41,15 @@ func (list MessageBatch) Less(i int, j int) bool {
 
 func (list MessageBatch) Len() int {
 	return len(list)
+}
+
+func (list MessageBatch) Bytes() []byte {
+	var buf bytes.Buffer
+	w := json.NewEncoder(&buf)
+	for _, msg := range list {
+		w.Encode(msg)
+	}
+	return buf.Bytes()
 }
 
 type MessageQueue struct {


### PR DESCRIPTION
This PR adds a Bytes() method to MessageBatch. In the ecs-logs kinesis destination, MessageBatch will be the primary streaming unit. On the receiving end, it is more efficient to reuse a single encoder over the entire batch rather than iterate over messages and marshal them individually. It's convenient to have this as a method of MessageBatch.

Note that this encodes the message objects separated by newlines, not as an array:
```
{
  "foo": "bar"
}
{
  "bar": "baz"
}
```