### PR TITLE
added cloudwatch retention policy (180 days)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # We need a go compiler that's based on an image with libsystemd-dev installed,
 # segment/golang give us just that.
-FROM segment/golang:latest
+FROM segment/golang:latest AS builder
 
 # Copy the ecs-logs sources so they can be built within the container.
 COPY . /go/src/github.com/segmentio/ecs-logs
@@ -8,11 +8,14 @@ COPY . /go/src/github.com/segmentio/ecs-logs
 # Build ecs-logs, then cleanup all unneeded packages.
 RUN cd /go/src/github.com/segmentio/ecs-logs && \
     govendor sync && \
-    go build -o /usr/local/bin/ecs-logs && \
-    apt-get remove -y apt-transport-https build-essential git curl docker-engine && \
-    apt-get autoremove -y && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/* /go/* /usr/local/go /usr/src/Makefile*
+    go build -o /usr/local/bin/ecs-logs
+
+FROM ubuntu:16.04
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    apt-get clean -y
+
+COPY --from=builder /usr/local/bin/ecs-logs /usr/local/bin/ecs-logs
 
 # Sets the container's entry point.
 ENTRYPOINT ["ecs-logs"]

--- a/lib/cloudwatchlogs/client.go
+++ b/lib/cloudwatchlogs/client.go
@@ -119,6 +119,13 @@ func createGroupAndStream(client *cloudwatchlogs.CloudWatchLogs, group string, s
 		return "", err
 	}
 
+	if _, err = client.PutRetentionPolicy(&cloudwatchlogs.PutRetentionPolicyInput{
+		LogGroupName: aws.String(group),
+		RetentionInDays: aws.Int64(90),
+	}); err != nil {
+		return "", err
+	}
+
 	_, err = client.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{
 		LogGroupName:  aws.String(group),
 		LogStreamName: aws.String(stream),

--- a/lib/cloudwatchlogs/client.go
+++ b/lib/cloudwatchlogs/client.go
@@ -121,9 +121,9 @@ func createGroupAndStream(client *cloudwatchlogs.CloudWatchLogs, group string, s
 
 	if _, err = client.PutRetentionPolicy(&cloudwatchlogs.PutRetentionPolicyInput{
 		LogGroupName: aws.String(group),
-		RetentionInDays: aws.Int64(90),
+		RetentionInDays: aws.Int64(180),
 	}); err != nil {
-		return "", err
+                fmt.Println(err.Error())
 	}
 
 	_, err = client.CreateLogStream(&cloudwatchlogs.CreateLogStreamInput{


### PR DESCRIPTION
1) $subj
2) improved Dockerfile. The resulting image is much smaller than it was before. We do not need all golang infrastructure during the application runtime.